### PR TITLE
FIX postgres timeout on option_group

### DIFF
--- a/aws/__examples__/.planshots.txt
+++ b/aws/__examples__/.planshots.txt
@@ -297,7 +297,7 @@ monitoring_interval:                         "0"
 monitoring_role_arn:                         <computed>
 multi_az:                                    "true"
 name:                                        <computed>
-option_group_name:                           <computed>
+option_group_name:                           "default:postgres-9-6"
 parameter_group_name:                        "test-postgres-production-pg96"
 password:                                    <sensitive>
 port:                                        <computed>

--- a/aws/rds/__examples__/.planshots.txt
+++ b/aws/rds/__examples__/.planshots.txt
@@ -53,7 +53,7 @@ monitoring_interval:                    "0"
 monitoring_role_arn:                    <computed>
 multi_az:                               "true"
 name:                                   <computed>
-option_group_name:                      "${!local.is_postgres ? local.option_group_name : \"\"}"
+option_group_name:                      "${!local.is_postgres ? local.option_group_name : \"default:postgres-${replace(var.engine_version, \".\", \"-\")}\"}"
 parameter_group_name:                   "rds-mysql-option-group-production-mysql57"
 password:                               <sensitive>
 port:                                   <computed>
@@ -268,7 +268,7 @@ monitoring_interval:                    "0"
 monitoring_role_arn:                    <computed>
 multi_az:                               "true"
 name:                                   <computed>
-option_group_name:                      <computed>
+option_group_name:                      "default:postgres-9-6"
 parameter_group_name:                   "${local.parameter_group_name}"
 password:                               <sensitive>
 port:                                   <computed>
@@ -363,7 +363,7 @@ monitoring_interval:                    "0"
 monitoring_role_arn:                    <computed>
 multi_az:                               "true"
 name:                                   <computed>
-option_group_name:                      <computed>
+option_group_name:                      "default:postgres-9-6"
 parameter_group_name:                   "rds-postgres-production-pg96"
 password:                               <sensitive>
 port:                                   <computed>

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -68,7 +68,7 @@ resource "aws_db_instance" "mod" {
   vpc_security_group_ids = ["${aws_security_group.sg_on_rds_instance.id}"]
   db_subnet_group_name = "${local.subnet_group_name}"
   parameter_group_name = "${local.parameter_group_name}"
-  option_group_name = "${!local.is_postgres ? local.option_group_name : ""}"
+  option_group_name = "${!local.is_postgres ? local.option_group_name : "default:postgres-${replace(var.engine_version, ".", "-")}"}"
   final_snapshot_identifier = "${var.name}-${var.env}-${var.engine}-final-snapshot"
   skip_final_snapshot = "${var.skip_final_snapshot}"
   publicly_accessible = true


### PR DESCRIPTION
If the option_group parameter is left empty, terraform will try and update the field on every run. Instead use the AWS default.