### PR TITLE
ADD enable_eip to ec2 module

### DIFF
--- a/aws/ec2/__examples__/.planshots.txt
+++ b/aws/ec2/__examples__/.planshots.txt
@@ -74,6 +74,96 @@ tags.Name:                                 "with-ami02"
 tenancy:                                   <computed>
 volume_tags.%:                             <computed>
 
++ module.with-eip.aws_eip.mod[0]
+id:                                        <computed>
+allocation_id:                             <computed>
+association_id:                            <computed>
+domain:                                    <computed>
+instance:                                  "${element(aws_instance.mod.*.id, count.index)}"
+network_interface:                         <computed>
+private_ip:                                <computed>
+public_ip:                                 <computed>
+vpc:                                       "true"
+
++ module.with-eip.aws_eip.mod[1]
+id:                                        <computed>
+allocation_id:                             <computed>
+association_id:                            <computed>
+domain:                                    <computed>
+instance:                                  "${element(aws_instance.mod.*.id, count.index)}"
+network_interface:                         <computed>
+private_ip:                                <computed>
+public_ip:                                 <computed>
+vpc:                                       "true"
+
++ module.with-eip.aws_instance.mod[0]
+id:                                        <computed>
+ami:                                       "ami-55ef662f"
+associate_public_ip_address:               "true"
+availability_zone:                         <computed>
+ebs_block_device.#:                        <computed>
+ebs_optimized:                             "false"
+ephemeral_block_device.#:                  <computed>
+instance_state:                            <computed>
+instance_type:                             "t2.small"
+ipv6_address_count:                        <computed>
+ipv6_addresses.#:                          <computed>
+key_name:                                  "without-ami"
+network_interface.#:                       <computed>
+network_interface_id:                      <computed>
+placement_group:                           <computed>
+primary_network_interface_id:              <computed>
+private_dns:                               <computed>
+private_ip:                                <computed>
+public_dns:                                <computed>
+public_ip:                                 <computed>
+root_block_device.#:                       "1"
+root_block_device.0.delete_on_termination: "true"
+root_block_device.0.volume_size:           "8"
+root_block_device.0.volume_type:           "gp2"
+security_groups.#:                         <computed>
+source_dest_check:                         "true"
+subnet_id:                                 "without-ami"
+tags.%:                                    "2"
+tags.Environment:                          "production"
+tags.Name:                                 "without-ami01"
+tenancy:                                   <computed>
+volume_tags.%:                             <computed>
+
++ module.with-eip.aws_instance.mod[1]
+id:                                        <computed>
+ami:                                       "ami-55ef662f"
+associate_public_ip_address:               "true"
+availability_zone:                         <computed>
+ebs_block_device.#:                        <computed>
+ebs_optimized:                             "false"
+ephemeral_block_device.#:                  <computed>
+instance_state:                            <computed>
+instance_type:                             "t2.small"
+ipv6_address_count:                        <computed>
+ipv6_addresses.#:                          <computed>
+key_name:                                  "without-ami"
+network_interface.#:                       <computed>
+network_interface_id:                      <computed>
+placement_group:                           <computed>
+primary_network_interface_id:              <computed>
+private_dns:                               <computed>
+private_ip:                                <computed>
+public_dns:                                <computed>
+public_ip:                                 <computed>
+root_block_device.#:                       "1"
+root_block_device.0.delete_on_termination: "true"
+root_block_device.0.volume_size:           "8"
+root_block_device.0.volume_type:           "gp2"
+security_groups.#:                         <computed>
+source_dest_check:                         "true"
+subnet_id:                                 "without-ami"
+tags.%:                                    "2"
+tags.Environment:                          "production"
+tags.Name:                                 "without-ami02"
+tenancy:                                   <computed>
+volume_tags.%:                             <computed>
+
 + module.without-ami.aws_instance.mod[0]
 id:                                        <computed>
 ami:                                       "ami-55ef662f"
@@ -141,5 +231,5 @@ tags.Environment:                          "production"
 tags.Name:                                 "without-ami02"
 tenancy:                                   <computed>
 volume_tags.%:                             <computed>
-Plan: 4 to add, 0 to change, 0 to destroy.
+Plan: 8 to add, 0 to change, 0 to destroy.
 

--- a/aws/ec2/__examples__/eip.tf
+++ b/aws/ec2/__examples__/eip.tf
@@ -1,0 +1,8 @@
+module "with-eip" {
+  source = "../"
+
+  enable_eip = true
+  key_name = "without-ami"
+  name = "without-ami"
+  subnets = ["without-ami"]
+}

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -34,3 +34,9 @@ resource "aws_instance" "mod" {
     ignore_changes = [ "key_name" ]
   }
 }
+
+resource "aws_eip" "mod" {
+  count = "${var.enable_eip ? var.count : 0}"
+  instance = "${element(aws_instance.mod.*.id, count.index)}"
+  vpc = true
+}

--- a/aws/ec2/outputs.tf
+++ b/aws/ec2/outputs.tf
@@ -3,5 +3,7 @@ output "instance_ids" {
 }
 
 output "public_ips" {
-  value = ["${aws_instance.mod.*.public_ip}"]
+  # Cannot use lists in a conditional statement
+  # https://github.com/hashicorp/terraform/issues/12453
+  value = ["${split(",", var.enable_eip ? join(",", aws_eip.mod.*.public_ip) : join(",", aws_instance.mod.*.public_ip))}"]
 }

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -15,6 +15,11 @@ variable "ebs_optimized" {
   description = "An Amazon EBS–optimized instance uses an optimized configuration stack and provides additional, dedicated capacity for Amazon EBS I/O. It is only available for certain instance types. http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html"
 }
 
+variable "enable_eip" {
+  default = false
+  description = "Enable EIP for instances"
+}
+
 variable "env" {
   default = "production"
 }


### PR DESCRIPTION
Allow's you to add eips to an instance inside the ec2 module by enabling the enable_eip variable.