### PR TITLE
Do not set db_subnet_group_name for RDS read replicas

### DIFF
--- a/aws/rds/__examples__/.planshots.txt
+++ b/aws/rds/__examples__/.planshots.txt
@@ -446,6 +446,110 @@ tags.%:                                 "1"
 tags.Name:                              "rds-rds-postgres_production-pg"
 vpc_id:                                 "rds-postgres"
 
++ module.read-replica.aws_db_instance.mod
+id:                                     <computed>
+address:                                <computed>
+allocated_storage:                      "5"
+allow_major_version_upgrade:            "true"
+apply_immediately:                      "true"
+arn:                                    <computed>
+auto_minor_version_upgrade:             "true"
+availability_zone:                      <computed>
+backup_retention_period:                "7"
+backup_window:                          <computed>
+ca_cert_identifier:                     <computed>
+character_set_name:                     <computed>
+copy_tags_to_snapshot:                  "false"
+db_subnet_group_name:                   <computed>
+endpoint:                               <computed>
+engine:                                 "postgres"
+engine_version:                         "9.6"
+final_snapshot_identifier:              "rds-postgres-production-postgres-final-snapshot"
+hosted_zone_id:                         <computed>
+identifier:                             "rds-postgres-production-postgres"
+identifier_prefix:                      <computed>
+instance_class:                         "db.t2.medium"
+kms_key_id:                             <computed>
+license_model:                          <computed>
+maintenance_window:                     <computed>
+monitoring_interval:                    "0"
+monitoring_role_arn:                    <computed>
+multi_az:                               "true"
+name:                                   <computed>
+option_group_name:                      "default:postgres-9-6"
+parameter_group_name:                   "rds-postgres-production-pg96"
+password:                               <sensitive>
+port:                                   <computed>
+publicly_accessible:                    "true"
+replicas.#:                             <computed>
+replicate_source_db:                    "primary-db-id"
+resource_id:                            <computed>
+skip_final_snapshot:                    "false"
+status:                                 <computed>
+storage_type:                           "gp2"
+timezone:                               <computed>
+username:                               "rds-postgresadmin"
+vpc_security_group_ids.#:               <computed>
+
++ module.read-replica.aws_db_parameter_group.mod
+id:                                     <computed>
+arn:                                    <computed>
+description:                            "postgres9.6 parameter group for rds-postgres production"
+family:                                 "postgres9.6"
+name:                                   "rds-postgres-production-pg96"
+name_prefix:                            <computed>
+
++ module.read-replica.aws_db_subnet_group.mod
+id:                                     <computed>
+arn:                                    <computed>
+description:                            "rds-postgres production db postgres subnet group"
+name:                                   "rds-postgres-production-pg-sg"
+name_prefix:                            <computed>
+subnet_ids.#:                           "1"
+subnet_ids.1294024653:                  "rds-postgres"
+
++ module.read-replica.aws_security_group.sg_for_access_by_sgs
+id:                                     <computed>
+description:                            "rds-postgres_production-rds-pg"
+egress.#:                               <computed>
+ingress.#:                              <computed>
+name:                                   "rds-postgres_production-rds-pg"
+owner_id:                               <computed>
+revoke_rules_on_delete:                 "false"
+tags.%:                                 "1"
+tags.Name:                              "rds-postgres_production-rds-pg"
+vpc_id:                                 "rds-postgres"
+
++ module.read-replica.aws_security_group.sg_on_rds_instance
+id:                                     <computed>
+description:                            "rds-rds-postgres_production-pg"
+egress.#:                               "1"
+egress.482069346.cidr_blocks.#:         "1"
+egress.482069346.cidr_blocks.0:         "0.0.0.0/0"
+egress.482069346.description:           ""
+egress.482069346.from_port:             "0"
+egress.482069346.ipv6_cidr_blocks.#:    "0"
+egress.482069346.prefix_list_ids.#:     "0"
+egress.482069346.protocol:              "-1"
+egress.482069346.security_groups.#:     "0"
+egress.482069346.self:                  "false"
+egress.482069346.to_port:               "0"
+ingress.#:                              "1"
+ingress.~2994424545.cidr_blocks.#:      "0"
+ingress.~2994424545.description:        ""
+ingress.~2994424545.from_port:          "5432"
+ingress.~2994424545.ipv6_cidr_blocks.#: "0"
+ingress.~2994424545.protocol:           "tcp"
+ingress.~2994424545.security_groups.#:  <computed>
+ingress.~2994424545.self:               "false"
+ingress.~2994424545.to_port:            "5432"
+name:                                   "rds-rds-postgres_production-pg"
+owner_id:                               <computed>
+revoke_rules_on_delete:                 "false"
+tags.%:                                 "1"
+tags.Name:                              "rds-rds-postgres_production-pg"
+vpc_id:                                 "rds-postgres"
+
 + module.sg-spec-postgres.aws_db_instance.mod
 id:                                     <computed>
 address:                                <computed>
@@ -548,5 +652,5 @@ revoke_rules_on_delete:                 "false"
 tags.%:                                 "1"
 tags.Name:                              "rds-sg-spec-postgres_production-pg"
 vpc_id:                                 "sg-spec-postgres"
-Plan: 28 to add, 0 to change, 0 to destroy.
+Plan: 33 to add, 0 to change, 0 to destroy.
 

--- a/aws/rds/__examples__/read_replica.tf
+++ b/aws/rds/__examples__/read_replica.tf
@@ -1,0 +1,10 @@
+module "read-replica" {
+  source = "../"
+
+  engine = "postgres"
+  engine_version = "9.6"
+  name = "rds-postgres"
+  subnets = ["rds-postgres"]
+  vpc_id = "rds-postgres"
+  source_db = "primary-db-id"
+}

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -66,7 +66,7 @@ resource "aws_db_instance" "mod" {
   backup_retention_period = "${var.backup_retention_period}"
   multi_az = "${var.multi_az}"
   vpc_security_group_ids = ["${concat(var.vpc_security_group_ids, list(aws_security_group.sg_on_rds_instance.id))}"]
-  db_subnet_group_name = "${local.subnet_group_name}"
+  db_subnet_group_name = "${var.source_db == "" ? local.subnet_group_name : ""}"
   parameter_group_name = "${local.parameter_group_name}"
   option_group_name = "${!local.is_postgres ? local.option_group_name : "default:postgres-${replace(var.engine_version, ".", "-")}"}"
   final_snapshot_identifier = "${var.name}-${var.env}-${var.engine}-final-snapshot"


### PR DESCRIPTION
This is my attempt to fix [this problem](https://github.com/tablexi/chef-repo/pull/1730#issuecomment-368077722): creating a RDS read replica instance where a `db_subnet_group_name` attribute is specified is invalid, and fails with the message

```
* aws_db_instance.mod: Error creating DB Instance: DBSubnetGroupNotAllowedFault: DbSubnetGroupName should not be specified for read replicas that are created in the same region as the master
	status code: 400, request id: 0f4615c3-08bc-437d-b9ce-f6185ae67514
```

Hence, if the module is being used to create a read-replica (which we know because a `source_db` has been set), we don’t attempt to set `db_subnet_group_name`.