### PR TITLE
Allow encryption in Redis elasticache

### DIFF
--- a/aws/elasticache/__examples__/.planshots.txt
+++ b/aws/elasticache/__examples__/.planshots.txt
@@ -86,6 +86,87 @@ tags.%:                                       "1"
 tags.Name:                                    "redis-production"
 vpc_id:                                       "redis"
 
++ module.encrypted_redis.aws_elasticache_parameter_group.mod
+id:                                           <computed>
+description:                                  "redis production env redis cluster param group"
+family:                                       "redis3.2"
+name:                                         "redis-production-params32"
+
++ module.encrypted_redis.aws_elasticache_replication_group.mod
+id:                                           <computed>
+apply_immediately:                            <computed>
+at_rest_encryption_enabled:                   "true"
+auto_minor_version_upgrade:                   "true"
+automatic_failover_enabled:                   "false"
+configuration_endpoint_address:               <computed>
+engine:                                       "redis"
+engine_version:                               "3.2.6"
+maintenance_window:                           <computed>
+node_type:                                    "cache.t2.micro"
+number_cache_clusters:                        "1"
+parameter_group_name:                         "${aws_elasticache_parameter_group.mod.id}"
+port:                                         "6379"
+primary_endpoint_address:                     <computed>
+replication_group_description:                "redis production redis instance"
+replication_group_id:                         "redis-production"
+security_group_ids.#:                         <computed>
+security_group_names.#:                       <computed>
+snapshot_window:                              <computed>
+subnet_group_name:                            "redis-production-redis-subnet"
+tags.%:                                       "2"
+tags.Description:                             "redis production redis instance"
+tags.Environment:                             "production"
+transit_encryption_enabled:                   "true"
+
++ module.encrypted_redis.aws_elasticache_subnet_group.mod
+id:                                           <computed>
+description:                                  "redis-production-redis-subnet"
+name:                                         "redis-production-redis-subnet"
+subnet_ids.#:                                 "1"
+subnet_ids.2066075671:                        "redis"
+
++ module.encrypted_redis.aws_security_group.sg_for_access_by_sgs
+id:                                           <computed>
+description:                                  "redis_production to redis"
+egress.#:                                     <computed>
+ingress.#:                                    <computed>
+name:                                         "redis_production-redis"
+owner_id:                                     <computed>
+revoke_rules_on_delete:                       "false"
+tags.%:                                       "1"
+tags.Name:                                    "production-redis"
+vpc_id:                                       "redis"
+
++ module.encrypted_redis.aws_security_group.sg_on_elasticache_instance
+id:                                           <computed>
+description:                                  "redis to redis_production"
+egress.#:                                     "1"
+egress.482069346.cidr_blocks.#:               "1"
+egress.482069346.cidr_blocks.0:               "0.0.0.0/0"
+egress.482069346.description:                 ""
+egress.482069346.from_port:                   "0"
+egress.482069346.ipv6_cidr_blocks.#:          "0"
+egress.482069346.prefix_list_ids.#:           "0"
+egress.482069346.protocol:                    "-1"
+egress.482069346.security_groups.#:           "0"
+egress.482069346.self:                        "false"
+egress.482069346.to_port:                     "0"
+ingress.#:                                    "1"
+ingress.~743784797.cidr_blocks.#:             "0"
+ingress.~743784797.description:               ""
+ingress.~743784797.from_port:                 "6379"
+ingress.~743784797.ipv6_cidr_blocks.#:        "0"
+ingress.~743784797.protocol:                  "tcp"
+ingress.~743784797.security_groups.#:         <computed>
+ingress.~743784797.self:                      "false"
+ingress.~743784797.to_port:                   "6379"
+name:                                         "redis-redis_production"
+owner_id:                                     <computed>
+revoke_rules_on_delete:                       "false"
+tags.%:                                       "1"
+tags.Name:                                    "redis-production"
+vpc_id:                                       "redis"
+
 + module.external_security_group_access.aws_elasticache_cluster.mod
 id:                                           <computed>
 apply_immediately:                            <computed>
@@ -234,5 +315,86 @@ revoke_rules_on_delete:                       "false"
 tags.%:                                       "1"
 tags.Name:                                    "redis-production"
 vpc_id:                                       "redis"
-Plan: 14 to add, 0 to change, 0 to destroy.
+
++ module.force_replication_group_redis.aws_elasticache_parameter_group.mod
+id:                                           <computed>
+description:                                  "redis production env redis cluster param group"
+family:                                       "redis2.8"
+name:                                         "redis-production-params28"
+
++ module.force_replication_group_redis.aws_elasticache_replication_group.mod
+id:                                           <computed>
+apply_immediately:                            <computed>
+at_rest_encryption_enabled:                   "false"
+auto_minor_version_upgrade:                   "true"
+automatic_failover_enabled:                   "false"
+configuration_endpoint_address:               <computed>
+engine:                                       "redis"
+engine_version:                               "2.8.17"
+maintenance_window:                           <computed>
+node_type:                                    "cache.t2.micro"
+number_cache_clusters:                        "1"
+parameter_group_name:                         "${aws_elasticache_parameter_group.mod.id}"
+port:                                         "6379"
+primary_endpoint_address:                     <computed>
+replication_group_description:                "redis production redis instance"
+replication_group_id:                         "redis-production"
+security_group_ids.#:                         <computed>
+security_group_names.#:                       <computed>
+snapshot_window:                              <computed>
+subnet_group_name:                            "redis-production-redis-subnet"
+tags.%:                                       "2"
+tags.Description:                             "redis production redis instance"
+tags.Environment:                             "production"
+transit_encryption_enabled:                   "false"
+
++ module.force_replication_group_redis.aws_elasticache_subnet_group.mod
+id:                                           <computed>
+description:                                  "redis-production-redis-subnet"
+name:                                         "redis-production-redis-subnet"
+subnet_ids.#:                                 "1"
+subnet_ids.2066075671:                        "redis"
+
++ module.force_replication_group_redis.aws_security_group.sg_for_access_by_sgs
+id:                                           <computed>
+description:                                  "redis_production to redis"
+egress.#:                                     <computed>
+ingress.#:                                    <computed>
+name:                                         "redis_production-redis"
+owner_id:                                     <computed>
+revoke_rules_on_delete:                       "false"
+tags.%:                                       "1"
+tags.Name:                                    "production-redis"
+vpc_id:                                       "redis"
+
++ module.force_replication_group_redis.aws_security_group.sg_on_elasticache_instance
+id:                                           <computed>
+description:                                  "redis to redis_production"
+egress.#:                                     "1"
+egress.482069346.cidr_blocks.#:               "1"
+egress.482069346.cidr_blocks.0:               "0.0.0.0/0"
+egress.482069346.description:                 ""
+egress.482069346.from_port:                   "0"
+egress.482069346.ipv6_cidr_blocks.#:          "0"
+egress.482069346.prefix_list_ids.#:           "0"
+egress.482069346.protocol:                    "-1"
+egress.482069346.security_groups.#:           "0"
+egress.482069346.self:                        "false"
+egress.482069346.to_port:                     "0"
+ingress.#:                                    "1"
+ingress.~743784797.cidr_blocks.#:             "0"
+ingress.~743784797.description:               ""
+ingress.~743784797.from_port:                 "6379"
+ingress.~743784797.ipv6_cidr_blocks.#:        "0"
+ingress.~743784797.protocol:                  "tcp"
+ingress.~743784797.security_groups.#:         <computed>
+ingress.~743784797.self:                      "false"
+ingress.~743784797.to_port:                   "6379"
+name:                                         "redis-redis_production"
+owner_id:                                     <computed>
+revoke_rules_on_delete:                       "false"
+tags.%:                                       "1"
+tags.Name:                                    "redis-production"
+vpc_id:                                       "redis"
+Plan: 24 to add, 0 to change, 0 to destroy.
 

--- a/aws/elasticache/__examples__/encrypted.tf
+++ b/aws/elasticache/__examples__/encrypted.tf
@@ -1,0 +1,13 @@
+module "encrypted_redis" {
+  source = "../"
+
+  engine = "redis"
+  engine_version = "3.2.6" # Cannot use 3.2.10 with encryption
+  name = "redis"
+  subnets = ["redis"]
+  vpc_id = "redis"
+
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  force_replication_group = true
+}

--- a/aws/elasticache/__examples__/force_replication_group.tf
+++ b/aws/elasticache/__examples__/force_replication_group.tf
@@ -1,0 +1,10 @@
+module "force_replication_group_redis" {
+  source = "../"
+
+  engine = "redis"
+  engine_version = "2.8.17"
+  name = "redis"
+  subnets = ["redis"]
+  vpc_id = "redis"
+  force_replication_group = true
+}

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -1,3 +1,7 @@
+variable "at_rest_encryption_enabled" {
+  default = false
+}
+
 variable "create_parameter_group" {
   default = true
   description = "Create a parameter group in this module"
@@ -14,6 +18,10 @@ variable "engine_version" {
 
 variable "env" {
   default = "production"
+}
+
+variable "force_replication_group" {
+  default = false
 }
 
 variable "name" {}
@@ -47,6 +55,10 @@ variable "sg_for_access_ids" {
 
 variable "subnets" {
   type = "list"
+}
+
+variable "transit_encryption_enabled" {
+  default = false
 }
 
 variable "vpc_id" {}


### PR DESCRIPTION
Also, allow forcing terraform to use the replication group rather than a cluster
because the encryption options are not available on clusters.