### PR TITLE
Allow specifying monitoring argument for EC2 instances

### DIFF
--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -18,6 +18,7 @@ resource "aws_instance" "mod" {
   vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
   subnet_id = "${element(var.subnets, count.index)}"
   associate_public_ip_address = "${var.associate_public_ip_address}"
+  monitoring = "${var.monitoring}"
 
   tags {
     Name = "${format("%s%02d", var.name, count.index + var.name_tag_starting_count)}"

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -58,4 +58,5 @@ variable "name" {
 
 variable "monitoring" {
   default = false
+  description = "If true, the launched EC2 instance will have detailed monitoring enabled."
 }

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -55,3 +55,7 @@ variable "vpc_security_group_ids" {
 variable "name" {
   description = "The name of the instance. This will be appended with the count number. IE test-app01."
 }
+
+variable "monitoring" {
+  default = false
+}


### PR DESCRIPTION
To be able to move the definition for `bookrags-app02` to use the EC2 module from this repo, per [these suggestions](https://github.com/tablexi/chef-repo/pull/1897#issuecomment-376567300), I need to be able to specify [the `monitoring` argument](https://www.terraform.io/docs/providers/aws/r/instance.html#monitoring) for the EC2 instance, because it is currently set to [`true` for `bookrags-app02`](https://github.com/tablexi/chef-repo/blob/dd55a6b4fe0f9e8f6119587955796dd498e14249/terraform/bookrags/ec2_content.tf#L40).

This PR adds support for doing so, while keeping the current default so nothing else is affected.