### PR TITLE
Decrease default value for deregistration_delay

### DIFF
--- a/aws/__examples__/.planshots.txt
+++ b/aws/__examples__/.planshots.txt
@@ -22,6 +22,7 @@ ip_address_type:                             <computed>
 load_balancer_type:                          "application"
 name:                                        "alb"
 security_groups.#:                           <computed>
+subnet_mapping.#:                            <computed>
 subnets.#:                                   <computed>
 tags.%:                                      "2"
 tags.Environment:                            "prod"
@@ -185,7 +186,7 @@ ssl_policy:                                  <computed>
 id:                                          <computed>
 arn:                                         <computed>
 arn_suffix:                                  <computed>
-deregistration_delay:                        "300"
+deregistration_delay:                        "30"
 health_check.#:                              "1"
 health_check.0.healthy_threshold:            "3"
 health_check.0.interval:                     "30"

--- a/aws/ec2/load_balancers/lb/__examples__/.planshots.txt
+++ b/aws/ec2/load_balancers/lb/__examples__/.planshots.txt
@@ -21,6 +21,7 @@ ip_address_type:                  <computed>
 load_balancer_type:               "application"
 name:                             "alb"
 security_groups.#:                <computed>
+subnet_mapping.#:                 <computed>
 subnets.#:                        "1"
 subnets.3701497050:               "alb"
 tags.%:                           "2"

--- a/aws/ec2/load_balancers/lb/target_listener/__examples__/.planshots.txt
+++ b/aws/ec2/load_balancers/lb/target_listener/__examples__/.planshots.txt
@@ -20,7 +20,7 @@ ssl_policy:                         <computed>
 id:                                 <computed>
 arn:                                <computed>
 arn_suffix:                         <computed>
-deregistration_delay:               "300"
+deregistration_delay:               "30"
 health_check.#:                     "1"
 health_check.0.healthy_threshold:   "3"
 health_check.0.interval:            "30"
@@ -80,7 +80,7 @@ ssl_policy:                         "ELBSecurityPolicy-2016-08"
 id:                                 <computed>
 arn:                                <computed>
 arn_suffix:                         <computed>
-deregistration_delay:               "300"
+deregistration_delay:               "30"
 health_check.#:                     "1"
 health_check.0.healthy_threshold:   "3"
 health_check.0.interval:            "30"
@@ -142,7 +142,7 @@ priority:                           "100"
 id:                                 <computed>
 arn:                                <computed>
 arn_suffix:                         <computed>
-deregistration_delay:               "300"
+deregistration_delay:               "30"
 health_check.#:                     "1"
 health_check.0.healthy_threshold:   "3"
 health_check.0.interval:            "30"

--- a/aws/ec2/load_balancers/lb/target_listener/variables.tf
+++ b/aws/ec2/load_balancers/lb/target_listener/variables.tf
@@ -30,7 +30,7 @@ variable "create_listener" {
 
 variable "deregistration_delay" {
   description = "The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused"
-  default = 300
+  default = 30
 }
 variable "health_check" {
   description = "Map of target health check parameters"


### PR DESCRIPTION
As mentioned in https://github.com/counterfind/terraform/pull/51, the deregistration delay configured for an ALB target group has the following meaning:

> Note that you can specify a value of up to 1 hour, and that Elastic Load Balancing waits the full amount of time specified, regardless of whether there are in-flight requests.

(from https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#deregistration-delay)

To allow maintenance operations to proceed more quickly (so we don’t have to wait a full 5 minutes between taking EC2 instances out of a target group, and shutting down app servers on the instance), this PR updates the default `deregistration_delay` to be 30 seconds (instead of 5 minutes).
