### PR TITLE
Allow specifying publicly_accessible for RDS module

### DIFF
--- a/aws/rds/__examples__/.planshots.txt
+++ b/aws/rds/__examples__/.planshots.txt
@@ -34,6 +34,112 @@ owner_id:                               <computed>
 revoke_rules_on_delete:                 "false"
 vpc_id:                                 "sg-spec-postgres"
 
++ module.not_publicly_accessible.aws_db_instance.mod
+id:                                     <computed>
+address:                                <computed>
+allocated_storage:                      "5"
+allow_major_version_upgrade:            "true"
+apply_immediately:                      "true"
+arn:                                    <computed>
+auto_minor_version_upgrade:             "true"
+availability_zone:                      <computed>
+backup_retention_period:                "7"
+backup_window:                          <computed>
+ca_cert_identifier:                     <computed>
+character_set_name:                     <computed>
+copy_tags_to_snapshot:                  "false"
+db_subnet_group_name:                   "not-publicly-accessible-production-pg-sg"
+endpoint:                               <computed>
+engine:                                 "postgres"
+engine_version:                         "9.6"
+final_snapshot_identifier:              "not-publicly-accessible-production-postgres-final-snapshot"
+hosted_zone_id:                         <computed>
+identifier:                             "not-publicly-accessible-production-postgres"
+identifier_prefix:                      <computed>
+instance_class:                         "db.t2.medium"
+kms_key_id:                             <computed>
+license_model:                          <computed>
+maintenance_window:                     <computed>
+monitoring_interval:                    "0"
+monitoring_role_arn:                    <computed>
+multi_az:                               "true"
+name:                                   <computed>
+option_group_name:                      "default:postgres-9-6"
+parameter_group_name:                   "not-publicly-accessible-production-pg96"
+password:                               <sensitive>
+port:                                   <computed>
+publicly_accessible:                    "false"
+replicas.#:                             <computed>
+resource_id:                            <computed>
+skip_final_snapshot:                    "false"
+status:                                 <computed>
+storage_encrypted:                      "false"
+storage_type:                           "gp2"
+timezone:                               <computed>
+username:                               "not-publicly-accessibleadmin"
+vpc_security_group_ids.#:               <computed>
+
++ module.not_publicly_accessible.aws_db_parameter_group.mod
+id:                                     <computed>
+arn:                                    <computed>
+description:                            "postgres9.6 parameter group for not-publicly-accessible production"
+family:                                 "postgres9.6"
+name:                                   "not-publicly-accessible-production-pg96"
+name_prefix:                            <computed>
+
++ module.not_publicly_accessible.aws_db_subnet_group.mod
+id:                                     <computed>
+arn:                                    <computed>
+description:                            "not-publicly-accessible production db postgres subnet group"
+name:                                   "not-publicly-accessible-production-pg-sg"
+name_prefix:                            <computed>
+subnet_ids.#:                           "1"
+subnet_ids.1294024653:                  "rds-postgres"
+
++ module.not_publicly_accessible.aws_security_group.sg_for_access_by_sgs
+id:                                     <computed>
+arn:                                    <computed>
+description:                            "not-publicly-accessible_production-rds-pg"
+egress.#:                               <computed>
+ingress.#:                              <computed>
+name:                                   "not-publicly-accessible_production-rds-pg"
+owner_id:                               <computed>
+revoke_rules_on_delete:                 "false"
+tags.%:                                 "1"
+tags.Name:                              "not-publicly-accessible_production-rds-pg"
+vpc_id:                                 "rds-postgres"
+
++ module.not_publicly_accessible.aws_security_group.sg_on_rds_instance
+id:                                     <computed>
+arn:                                    <computed>
+description:                            "rds-not-publicly-accessible_production-pg"
+egress.#:                               "1"
+egress.482069346.cidr_blocks.#:         "1"
+egress.482069346.cidr_blocks.0:         "0.0.0.0/0"
+egress.482069346.description:           ""
+egress.482069346.from_port:             "0"
+egress.482069346.ipv6_cidr_blocks.#:    "0"
+egress.482069346.prefix_list_ids.#:     "0"
+egress.482069346.protocol:              "-1"
+egress.482069346.security_groups.#:     "0"
+egress.482069346.self:                  "false"
+egress.482069346.to_port:               "0"
+ingress.#:                              "1"
+ingress.~2994424545.cidr_blocks.#:      "0"
+ingress.~2994424545.description:        ""
+ingress.~2994424545.from_port:          "5432"
+ingress.~2994424545.ipv6_cidr_blocks.#: "0"
+ingress.~2994424545.protocol:           "tcp"
+ingress.~2994424545.security_groups.#:  <computed>
+ingress.~2994424545.self:               "false"
+ingress.~2994424545.to_port:            "5432"
+name:                                   "rds-not-publicly-accessible_production-pg"
+owner_id:                               <computed>
+revoke_rules_on_delete:                 "false"
+tags.%:                                 "1"
+tags.Name:                              "rds-not-publicly-accessible_production-pg"
+vpc_id:                                 "rds-postgres"
+
 + module.rds-mysql-option-group.aws_db_instance.mod
 id:                                     <computed>
 address:                                <computed>
@@ -671,5 +777,5 @@ revoke_rules_on_delete:                 "false"
 tags.%:                                 "1"
 tags.Name:                              "rds-sg-spec-postgres_production-pg"
 vpc_id:                                 "sg-spec-postgres"
-Plan: 33 to add, 0 to change, 0 to destroy.
+Plan: 38 to add, 0 to change, 0 to destroy.
 

--- a/aws/rds/__examples__/not_publicly_accessible.tf
+++ b/aws/rds/__examples__/not_publicly_accessible.tf
@@ -1,0 +1,10 @@
+module "not_publicly_accessible" {
+  source = "../"
+
+  engine = "postgres"
+  engine_version = "9.6"
+  name = "not-publicly-accessible"
+  publicly_accessible = false
+  subnets = ["rds-postgres"]
+  vpc_id = "rds-postgres"
+}

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -72,7 +72,7 @@ resource "aws_db_instance" "mod" {
   final_snapshot_identifier = "${var.name}-${var.env}-${var.engine}-final-snapshot"
   skip_final_snapshot = "${var.skip_final_snapshot}"
   storage_encrypted = "${var.storage_encrypted}"
-  publicly_accessible = true
+  publicly_accessible = "${var.publicly_accessible}"
   auto_minor_version_upgrade = "${var.auto_minor_version_upgrade}"
   allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
   apply_immediately = "${var.apply_immediately}"

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -82,6 +82,11 @@ variable "port" {
   default = ""
 }
 
+variable "publicly_accessible" {
+  description = "Bool to control if instance is publicly accessible."
+  default = true
+}
+
 variable "sg_cidr_blocks" {
   description = "cidr_blocks to give RDS port access to."
   default = []


### PR DESCRIPTION
Allows creating RDS instances that are not marked as publicly accessible.