### PR TITLE
Do not specify count for data source aws_ami.mod

### DIFF
--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -1,18 +1,16 @@
 data "aws_ami" "mod" {
-  count = "${var.ami == "" ? 1 : 0}"
   most_recent = true
+  owners      = ["amazon"]
 
   filter {
-    name = "name"
+    name   = "name"
     values = ["amzn-ami-hvm-*x86_64-gp2"]
   }
-
-  owners = ["amazon"]
 }
 
 resource "aws_instance" "mod" {
   count = "${var.count}"
-  ami = "${var.ami != "" ? var.ami : element(concat(data.aws_ami.mod.*.id, list("")), 0)}"
+  ami = "${var.ami != "" ? var.ami : data.aws_ami.mod.id}"
   instance_type = "${var.type}"
   key_name = "${var.key_name}"
   vpc_security_group_ids = ["${var.vpc_security_group_ids}"]


### PR DESCRIPTION
If the ami being passed into this module comes as a computed value (for example, because we’re making an `aws_ami_copy` from another image), the count value becomes a computed value, and Terraform does not allow this (so it results in an error).

Since a data source doesn’t create any resources, we don’t need to specify its count—it can always be present, and in the resource `aws_instance` we’ll just use it, or not.

As expected, 96c36d8 doesn’t change any of the existing plans, but it allows us to use the module like so:

```
locals {
  amazon_linux_ami_id = "ami-97785bed"
}

resource "aws_ami_copy" "encrypted_amazon_linux" {
  description       = "Encrypted copy of ${local.amazon_linux_ami_id}"
  encrypted         = true
  name              = "${local.amazon_linux_ami_id}-encrypted-copy"
  source_ami_id     = "${local.amazon_linux_ami_id}"
  source_ami_region = "us-east-1"
}

module "staging" {
  source = "github.com/tablexi/terraform_modules?ref=96c36d8//aws/ec2"
  ami      = "${aws_ami_copy.encrypted_amazon_linux.id}"
}
```

Whereas previously, this would blow up with:

```
Error: Error refreshing state: 1 error(s) occurred:

* module.staging.data.aws_ami.mod: data.aws_ami.mod: value of 'count' cannot be computed
```