### PR TITLE
Spin off database replica module into aws/database_replica

### DIFF
--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -47,8 +47,6 @@ resource "aws_db_instance" "mod" {
   instance_class = "${var.node_type}"
   storage_type = "${local.storage_type}"
   allocated_storage = "${local.allocated_storage}"
-  username = "${var.username != "" ? var.username : "${var.name}${var.username_suffix}"}"
-  password = "nopassword"
   backup_retention_period = "${var.backup_retention_period}"
   multi_az = "${var.multi_az}"
   vpc_security_group_ids = ["${concat(var.vpc_security_group_ids, list(aws_security_group.sg_on_rds_instance.id))}"]

--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -1,0 +1,105 @@
+data "aws_db_instance" "source_db" {
+  db_instance_identifier = "${var.source_db}"
+}
+
+locals {
+  engine_nickname = "${local.is_postgres ? "pg" : "mysql"}"
+  family = "${var.engine}${var.engine_version}"
+  is_postgres = "${var.engine == "postgres" ? true : false}"
+  option_group_name = "${var.name}-${var.env}-${local.engine_nickname}${replace(var.engine_version, ".", "")}"
+  parameter_group_name = "${var.parameter_group_name != "" ? var.parameter_group_name : "${var.name}-${var.env}-${local.engine_nickname}${replace(var.engine_version, ".", "")}"}"
+  port = "${local.is_postgres ? 5432 : 3306}"
+  sg_on_rds_instance_name = "rds-${var.name}_${var.env}-${local.engine_nickname}"
+  subnet_group_name = "${var.subnet_group_name != "" ? var.subnet_group_name : "${var.name}-${var.env}-${local.engine_nickname}-sg"}"
+}
+
+resource "aws_db_subnet_group" "mod" {
+  count = "${var.create_db_subnet_group ? 1 : 0}"
+  name = "${local.subnet_group_name}"
+  description = "${var.name} ${var.env} db ${var.engine} subnet group"
+  subnet_ids = ["${var.subnets}"]
+
+  lifecycle {
+    create_before_destroy = true
+    # Apparently subnet groups cannot be changed within the same VPC. Even
+    # though the AWS documentation says otherwise.
+    # http://serverfault.com/a/817598
+    ignore_changes = ["name",]
+  }
+}
+
+resource "aws_db_parameter_group" "mod" {
+  count = "${var.parameter_group_provided ? 0 : 1}"
+  name = "${local.parameter_group_name}"
+  family = "${local.family}"
+  description = "${local.family} parameter group for ${var.name} ${var.env}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_db_option_group" "mod" {
+  count = "${local.is_postgres ? 0 : 1}"
+  name = "${local.option_group_name}"
+  engine_name = "${var.engine}"
+  major_engine_version = "${var.engine_version}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_db_instance" "mod" {
+  identifier = "${var.identifier != "" ? var.identifier : "${var.name}-${var.env}-${var.engine}"}"
+  replicate_source_db  = "${var.source_db}"
+  engine = "${var.engine}"
+  engine_version = "${var.engine_version}"
+  instance_class = "${var.node_type}"
+  storage_type = "${var.storage_type}"
+  allocated_storage = "${var.storage}"
+  username = "${var.username != "" ? var.username : "${var.name}${var.username_suffix}"}"
+  password = "nopassword"
+  backup_retention_period = "${var.backup_retention_period}"
+  multi_az = "${var.multi_az}"
+  vpc_security_group_ids = ["${concat(var.vpc_security_group_ids, list(aws_security_group.sg_on_rds_instance.id))}"]
+  db_subnet_group_name = "${var.source_db == "" ? local.subnet_group_name : ""}"
+  parameter_group_name = "${local.parameter_group_name}"
+  option_group_name = "${!local.is_postgres ? local.option_group_name : "default:postgres-${replace(var.engine_version, ".", "-")}"}"
+  final_snapshot_identifier = "${var.name}-${var.env}-${var.engine}-final-snapshot"
+  skip_final_snapshot = "${var.skip_final_snapshot}"
+  storage_encrypted = "${var.storage_encrypted}"
+  publicly_accessible = "${var.publicly_accessible}"
+  auto_minor_version_upgrade = "${var.auto_minor_version_upgrade}"
+  allow_major_version_upgrade = true
+  apply_immediately = true
+}
+
+resource "aws_security_group" "sg_on_rds_instance" {
+  name = "${local.sg_on_rds_instance_name}"
+  description = "${local.sg_on_rds_instance_name}"
+  vpc_id = "${var.vpc_id}"
+
+  ingress {
+    from_port = "${local.port}"
+    to_port = "${local.port}"
+    protocol = "tcp"
+    security_groups = ["${var.security_groups_for_ingress}"]
+    cidr_blocks = ["${var.sg_cidr_blocks}"]
+  }
+
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    "Name" = "${local.sg_on_rds_instance_name}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -3,8 +3,10 @@ data "aws_db_instance" "source_db" {
 }
 
 locals {
+  allocated_storage = "${data.aws_db_instance.source_db.allocated_storage}"
   engine = "${data.aws_db_instance.source_db.engine}"
   storage_encrypted = "${data.aws_db_instance.source_db.storage_encrypted}"
+  storage_type = "${data.aws_db_instance.source_db.storage_type}"
 
   engine_nickname = "${local.is_postgres ? "pg" : "mysql"}"
   family = "${local.engine}${var.engine_version}"
@@ -43,8 +45,8 @@ resource "aws_db_instance" "mod" {
   engine = "${local.engine}"
   engine_version = "${var.engine_version}"
   instance_class = "${var.node_type}"
-  storage_type = "${var.storage_type}"
-  allocated_storage = "${var.storage}"
+  storage_type = "${local.storage_type}"
+  allocated_storage = "${local.allocated_storage}"
   username = "${var.username != "" ? var.username : "${var.name}${var.username_suffix}"}"
   password = "nopassword"
   backup_retention_period = "${var.backup_retention_period}"

--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -5,14 +5,15 @@ data "aws_db_instance" "source_db" {
 locals {
   allocated_storage = "${data.aws_db_instance.source_db.allocated_storage}"
   engine = "${data.aws_db_instance.source_db.engine}"
+  engine_version = "${var.engine_version != "" ? var.engine_version : data.aws_db_instance.source_db.engine_version}"
   storage_encrypted = "${data.aws_db_instance.source_db.storage_encrypted}"
   storage_type = "${data.aws_db_instance.source_db.storage_type}"
 
   engine_nickname = "${local.is_postgres ? "pg" : "mysql"}"
-  family = "${local.engine}${var.engine_version}"
+  family = "${local.engine}${local.engine_version}"
   is_postgres = "${local.engine == "postgres" ? true : false}"
-  option_group_name = "${var.name}-${var.env}-${local.engine_nickname}${replace(var.engine_version, ".", "")}"
-  parameter_group_name = "${var.parameter_group_name != "" ? var.parameter_group_name : "${var.name}-${var.env}-${local.engine_nickname}${replace(var.engine_version, ".", "")}"}"
+  option_group_name = "${var.name}-${var.env}-${local.engine_nickname}${replace(local.engine_version, ".", "")}"
+  parameter_group_name = "${var.parameter_group_name != "" ? var.parameter_group_name : "${var.name}-${var.env}-${local.engine_nickname}${replace(local.engine_version, ".", "")}"}"
   port = "${local.is_postgres ? 5432 : 3306}"
   sg_on_rds_instance_name = "rds-${var.name}_${var.env}-${local.engine_nickname}"
 }
@@ -32,7 +33,7 @@ resource "aws_db_option_group" "mod" {
   count = "${local.is_postgres ? 0 : 1}"
   name = "${local.option_group_name}"
   engine_name = "${local.engine}"
-  major_engine_version = "${var.engine_version}"
+  major_engine_version = "${local.engine_version}"
 
   lifecycle {
     create_before_destroy = true
@@ -43,7 +44,7 @@ resource "aws_db_instance" "mod" {
   identifier = "${var.identifier != "" ? var.identifier : "${var.name}-${var.env}-${local.engine}"}"
   replicate_source_db  = "${var.source_db}"
   engine = "${local.engine}"
-  engine_version = "${var.engine_version}"
+  engine_version = "${local.engine_version}"
   instance_class = "${var.node_type}"
   storage_type = "${local.storage_type}"
   allocated_storage = "${local.allocated_storage}"
@@ -51,7 +52,7 @@ resource "aws_db_instance" "mod" {
   multi_az = "${var.multi_az}"
   vpc_security_group_ids = ["${concat(var.vpc_security_group_ids, list(aws_security_group.sg_on_rds_instance.id))}"]
   parameter_group_name = "${local.parameter_group_name}"
-  option_group_name = "${!local.is_postgres ? local.option_group_name : "default:postgres-${replace(var.engine_version, ".", "-")}"}"
+  option_group_name = "${!local.is_postgres ? local.option_group_name : "default:postgres-${replace(local.engine_version, ".", "-")}"}"
   final_snapshot_identifier = "${var.name}-${var.env}-${local.engine}-final-snapshot"
   skip_final_snapshot = "${var.skip_final_snapshot}"
   storage_encrypted = "${local.storage_encrypted}"

--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -4,6 +4,7 @@ data "aws_db_instance" "source_db" {
 
 locals {
   engine = "${data.aws_db_instance.source_db.engine}"
+  storage_encrypted = "${data.aws_db_instance.source_db.storage_encrypted}"
 
   engine_nickname = "${local.is_postgres ? "pg" : "mysql"}"
   family = "${local.engine}${var.engine_version}"
@@ -53,7 +54,7 @@ resource "aws_db_instance" "mod" {
   option_group_name = "${!local.is_postgres ? local.option_group_name : "default:postgres-${replace(var.engine_version, ".", "-")}"}"
   final_snapshot_identifier = "${var.name}-${var.env}-${local.engine}-final-snapshot"
   skip_final_snapshot = "${var.skip_final_snapshot}"
-  storage_encrypted = "${var.storage_encrypted}"
+  storage_encrypted = "${local.storage_encrypted}"
   publicly_accessible = "${var.publicly_accessible}"
   auto_minor_version_upgrade = "${var.auto_minor_version_upgrade}"
   allow_major_version_upgrade = true

--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -75,7 +75,7 @@ resource "aws_security_group" "sg_on_rds_instance" {
     to_port = "${local.port}"
     protocol = "tcp"
     security_groups = ["${var.security_groups_for_ingress}"]
-    cidr_blocks = ["${var.sg_cidr_blocks}"]
+    cidr_blocks = ["${var.cidr_blocks_for_ingress}"]
   }
 
   egress {

--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -1,13 +1,13 @@
-data "aws_db_instance" "source_db" {
+data "aws_db_instance" "source_database" {
   db_instance_identifier = "${var.source_db}"
 }
 
 locals {
-  allocated_storage = "${data.aws_db_instance.source_db.allocated_storage}"
-  engine = "${data.aws_db_instance.source_db.engine}"
-  engine_version = "${var.engine_version != "" ? var.engine_version : data.aws_db_instance.source_db.engine_version}"
-  storage_encrypted = "${data.aws_db_instance.source_db.storage_encrypted}"
-  storage_type = "${data.aws_db_instance.source_db.storage_type}"
+  allocated_storage = "${data.aws_db_instance.source_database.allocated_storage}"
+  engine = "${data.aws_db_instance.source_database.engine}"
+  engine_version = "${var.engine_version != "" ? var.engine_version : data.aws_db_instance.source_database.engine_version}"
+  storage_encrypted = "${data.aws_db_instance.source_database.storage_encrypted}"
+  storage_type = "${data.aws_db_instance.source_database.storage_type}"
 
   major_engine_version = "${join(".", slice(split(".", local.engine_version), 0, 2))}"
   default_option_and_parameter_group_name = "${var.name}-${var.env}-${local.engine_nickname}${replace(local.major_engine_version, ".", "")}"
@@ -45,7 +45,7 @@ resource "aws_db_option_group" "mod" {
 
 resource "aws_db_instance" "mod" {
   identifier = "${var.identifier != "" ? var.identifier : "${var.name}-${var.env}-${local.engine}"}"
-  replicate_source_db  = "${var.source_db}"
+  replicate_source_db = "${data.aws_db_instance.source_database.id}"
   engine = "${local.engine}"
   engine_version = "${local.engine_version}"
   instance_class = "${var.node_type}"

--- a/aws/database_replica/outputs.tf
+++ b/aws/database_replica/outputs.tf
@@ -1,0 +1,28 @@
+output "endpoint" {
+  value = "${aws_db_instance.mod.address}"
+}
+
+output "env" {
+  value = "${var.env}"
+}
+
+output "family" {
+  value = "${local.family}"
+}
+
+output "name" {
+  value = "${var.name}"
+}
+
+output "port" {
+  value = "${local.port}"
+}
+
+output "rds_id" {
+  value = "${aws_db_instance.mod.id}"
+}
+
+output "sg_on_rds_instance_id" {
+  value = "${aws_security_group.sg_on_rds_instance.id}"
+}
+

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -5,7 +5,7 @@ variable "auto_minor_version_upgrade" {
 
 variable "backup_retention_period" {
   description = "Backup retention period for AWS RDS instance in days."
-  default = 7
+  default = 0
 }
 
 variable "env" {

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -77,11 +77,6 @@ variable "storage" {
   default = 5
 }
 
-variable "storage_encrypted" {
-  description = "Encryption at rest"
-  default = false
-}
-
 variable "storage_type" {
   description = "Volume type to use.  Options: Standard(magnetic), gp2(SSD), or io1(provisioned IOPS SSD)"
   default = "gp2"

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -8,11 +8,6 @@ variable "backup_retention_period" {
   default = 7
 }
 
-variable "create_db_subnet_group" {
-  description = "Create a db subnet group specific to this database"
-  default = true
-}
-
 variable "env" {
   description = "Environment the RDS instance is associated with."
   default = "production"
@@ -92,15 +87,6 @@ variable "storage_type" {
   default = "gp2"
 }
 
-variable "subnets" {
-  description = "A list of subnets that the RDS instance can be added to."
-  type = "list"
-}
-
-variable "subnet_group_name" {
-  description = "Set db subnet group name"
-  default = ""
-}
 variable "username" {
   description = "RDS instance username"
   default = ""

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -1,0 +1,127 @@
+variable "auto_minor_version_upgrade" {
+  description = "Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window."
+  default = true
+}
+
+variable "backup_retention_period" {
+  description = "Backup retention period for AWS RDS instance in days."
+  default = 7
+}
+
+variable "create_db_subnet_group" {
+  description = "Create a db subnet group specific to this database"
+  default = true
+}
+
+variable "env" {
+  description = "Environment the RDS instance is associated with."
+  default = "production"
+}
+
+variable "engine" {
+  description = "Postgres, MySQL, etc."
+  # default = "postgres"
+}
+
+variable "engine_version" {
+  description = "Version # of the Postgres or MySQL installation. Do not include patch version as it is auto upgraded."
+  # default = "9.6"
+}
+
+variable "identifier" {
+  description = "Set the identifier for the instance"
+  default = ""
+}
+
+variable "multi_az" {
+  description = "AWS RDS automatically creates a primary DB Instance and synchronously replicates the data to a standby instance in a different Availability Zone."
+  default = true
+}
+
+variable "name" {
+  description = "Name of the RDS instance and various RDS services (EG subnet group and security groups)."
+}
+
+variable "node_type" {
+  description = "AWS RDS instance type."
+  default = "db.t2.medium"
+}
+
+variable "parameter_group_name" {
+  description = "Name of a parameter group to use with the RDS instance."
+  default = ""
+}
+
+variable "parameter_group_provided" {
+  description = "If the parameter_group_name is provided, must be set to true."
+  default = false
+}
+
+variable "publicly_accessible" {
+  description = "Bool to control if instance is publicly accessible."
+  default = true
+}
+
+variable "security_groups_for_ingress" {
+  description = "Security groups which should be allowed ingress on the RDS instance."
+  default = []
+}
+
+variable "sg_cidr_blocks" {
+  description = "cidr_blocks to give RDS port access to."
+  default = []
+}
+
+variable "skip_final_snapshot" {
+  description = "Skip final snapshot before destroying instance."
+  default = false
+}
+
+variable "source_db" {
+  description = "recplication source db"
+  default = ""
+}
+
+variable "storage" {
+  description = "Volume storage size for the RDS instance in gigabytes."
+  default = 5
+}
+
+variable "storage_encrypted" {
+  description = "Encryption at rest"
+  default = false
+}
+
+variable "storage_type" {
+  description = "Volume type to use.  Options: Standard(magnetic), gp2(SSD), or io1(provisioned IOPS SSD)"
+  default = "gp2"
+}
+
+variable "subnets" {
+  description = "A list of subnets that the RDS instance can be added to."
+  type = "list"
+}
+
+variable "subnet_group_name" {
+  description = "Set db subnet group name"
+  default = ""
+}
+variable "username" {
+  description = "RDS instance username"
+  default = ""
+}
+
+variable "username_suffix" {
+  description = "Allows for greater customization of the RDS instance superuser.  The username arguments starts with the name variable and then this variable is appended to it."
+  default = "admin"
+}
+
+variable "vpc_id" {
+  description = "VPC id to associate this RDS instance with."
+}
+
+variable "vpc_security_group_ids" {
+  description = "Additional security group ids to associate this RDS instance with."
+  type = "list"
+  default = []
+}

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -25,7 +25,7 @@ variable "identifier" {
 
 variable "multi_az" {
   description = "AWS RDS automatically creates a primary DB Instance and synchronously replicates the data to a standby instance in a different Availability Zone."
-  default = true
+  default = false
 }
 
 variable "name" {

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -57,8 +57,8 @@ variable "security_groups_for_ingress" {
   default = []
 }
 
-variable "sg_cidr_blocks" {
-  description = "cidr_blocks to give RDS port access to."
+variable "cidr_blocks_for_ingress" {
+  description = "CIDR blocks which should be allowed ingress on the RDS instance."
   default = []
 }
 

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -64,7 +64,7 @@ variable "sg_cidr_blocks" {
 
 variable "skip_final_snapshot" {
   description = "Skip final snapshot before destroying instance."
-  default = false
+  default = true
 }
 
 variable "source_db" {

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -14,8 +14,8 @@ variable "env" {
 }
 
 variable "engine_version" {
-  description = "Version # of the Postgres or MySQL installation. Do not include patch version as it is auto upgraded."
-  # default = "9.6"
+  description = "Engine version. Defaults to the version of the source database."
+  default = ""
 }
 
 variable "identifier" {

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -72,16 +72,6 @@ variable "source_db" {
   default = ""
 }
 
-variable "username" {
-  description = "RDS instance username"
-  default = ""
-}
-
-variable "username_suffix" {
-  description = "Allows for greater customization of the RDS instance superuser.  The username arguments starts with the name variable and then this variable is appended to it."
-  default = "admin"
-}
-
 variable "vpc_id" {
   description = "VPC id to associate this RDS instance with."
 }

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -72,16 +72,6 @@ variable "source_db" {
   default = ""
 }
 
-variable "storage" {
-  description = "Volume storage size for the RDS instance in gigabytes."
-  default = 5
-}
-
-variable "storage_type" {
-  description = "Volume type to use.  Options: Standard(magnetic), gp2(SSD), or io1(provisioned IOPS SSD)"
-  default = "gp2"
-}
-
 variable "username" {
   description = "RDS instance username"
   default = ""

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -18,11 +18,6 @@ variable "env" {
   default = "production"
 }
 
-variable "engine" {
-  description = "Postgres, MySQL, etc."
-  # default = "postgres"
-}
-
 variable "engine_version" {
   description = "Version # of the Postgres or MySQL installation. Do not include patch version as it is auto upgraded."
   # default = "9.6"


### PR DESCRIPTION
This PR introduces `aws/database_replica`, which I started from the existing `aws/rds`. Using a separate module allows us to drastically reduce the number of variables that need to be passed in, since we can get these from the source database. This approach makes it easier to create replicas, and it also ensures that the values that AWS will make the same anway, are the same in configuration (things like the subnet group, engine, etc.)

This is just a start, and I’ll soon have a companion PR in `chef-repo` that shows the effect of this PR. My goal is to simplify the code in both `aws/rds` and `aws/database_replica` soon, and this is a small step in that direction.