### PR TITLE
Use default option groups on databases instead of the empty ones we create

### DIFF
--- a/aws/__examples__/.planshots.txt
+++ b/aws/__examples__/.planshots.txt
@@ -254,7 +254,7 @@ monitoring_interval:                         "0"
 monitoring_role_arn:                         <computed>
 multi_az:                                    "true"
 name:                                        <computed>
-option_group_name:                           "test-mysql-production-mysql57"
+option_group_name:                           "default:mysql-5-7"
 parameter_group_name:                        "test-mysql-production-mysql57"
 password:                                    <sensitive>
 port:                                        <computed>

--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -55,7 +55,7 @@ resource "aws_db_instance" "mod" {
   multi_az = "${var.multi_az}"
   vpc_security_group_ids = ["${concat(var.vpc_security_group_ids, list(aws_security_group.sg_on_rds_instance.id))}"]
   parameter_group_name = "${local.parameter_group_name}"
-  option_group_name = "${!local.is_postgres ? local.option_group_name : "default:postgres-${replace(local.major_engine_version, ".", "-")}"}"
+  option_group_name = "${"default:${local.engine}-${replace(local.major_engine_version, ".", "-")}"}"
   final_snapshot_identifier = "${var.name}-${var.env}-${local.engine}-final-snapshot"
   skip_final_snapshot = "${var.skip_final_snapshot}"
   storage_encrypted = "${local.storage_encrypted}"

--- a/aws/rds/__examples__/.planshots.txt
+++ b/aws/rds/__examples__/.planshots.txt
@@ -148,7 +148,7 @@ monitoring_interval:                           "0"
 monitoring_role_arn:                           <computed>
 multi_az:                                      "true"
 name:                                          <computed>
-option_group_name:                             "rds-mysql-production-mysql57"
+option_group_name:                             "default:mysql-5-7"
 parameter_group_name:                          "rds-mysql-production-mysql57"
 password:                                      <sensitive>
 port:                                          <computed>

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -61,7 +61,7 @@ resource "aws_db_instance" "mod" {
   vpc_security_group_ids = ["${concat(var.vpc_security_group_ids, list(aws_security_group.sg_on_rds_instance.id))}"]
   db_subnet_group_name = "${var.source_db == "" ? local.subnet_group_name : ""}"
   parameter_group_name = "${local.parameter_group_name}"
-  option_group_name = "${!local.is_postgres ? local.option_group_name : "default:postgres-${replace(var.engine_version, ".", "-")}"}"
+  option_group_name = "${"default:${var.engine}-${replace(var.engine_version, ".", "-")}"}"
   final_snapshot_identifier = "${var.name}-${var.env}-${var.engine}-final-snapshot"
   skip_final_snapshot = "${var.skip_final_snapshot}"
   storage_encrypted = "${var.storage_encrypted}"


### PR DESCRIPTION
This PR sets the RDS instances we create to use the default option groups provided by AWS. This way, we can decrease our footprint since we never use option groups anywhere, so it doesn’t make too much sense to create empty ones, as opposed to just using the [default empty ones that AWS creates anyway](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html#Overview.OptionGroups).

The first step will switch over the RDS instances, but doesn’t delete the option groups yet — option groups are associated with database snapshots as well, so to be able to clean that up fully, we’ll need to wait until the largest backup retention period is over, and then I’ll submit another PR that removes the option groups and cleans up the code around them.