### PR TITLE
Stop creating empty, unused DB option groups

### DIFF
--- a/aws/__examples__/.planshots.txt
+++ b/aws/__examples__/.planshots.txt
@@ -269,15 +269,6 @@ timezone:                                    <computed>
 username:                                    "test-mysqladmin"
 vpc_security_group_ids.#:                    <computed>
 
-+ module.mysql.aws_db_option_group.mod
-id:                                          <computed>
-arn:                                         <computed>
-engine_name:                                 "mysql"
-major_engine_version:                        "5.7"
-name:                                        "test-mysql-production-mysql57"
-name_prefix:                                 <computed>
-option_group_description:                    "Managed by Terraform"
-
 + module.mysql.aws_db_parameter_group.mod
 id:                                          <computed>
 arn:                                         <computed>
@@ -849,5 +840,5 @@ ipv6_cidr_block:                             <computed>
 main_route_table_id:                         <computed>
 tags.%:                                      "1"
 tags.Name:                                   "vpc"
-Plan: 62 to add, 1 to change, 0 to destroy.
+Plan: 61 to add, 1 to change, 0 to destroy.
 

--- a/aws/application_load_balancer/__examples__/.planshots.txt
+++ b/aws/application_load_balancer/__examples__/.planshots.txt
@@ -521,7 +521,6 @@ id:                                                   <computed>
 access_logs.#:                                        "1"
 access_logs.0.bucket:                                 "${aws_s3_bucket.load_balancer_access_logs.id}"
 access_logs.0.enabled:                                "true"
-access_logs.0.prefix:                                 <computed>
 arn:                                                  <computed>
 arn_suffix:                                           <computed>
 dns_name:                                             <computed>

--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -15,7 +15,6 @@ locals {
   engine_nickname = "${local.is_postgres ? "pg" : "mysql"}"
   family = "${local.engine}${local.major_engine_version}"
   is_postgres = "${local.engine == "postgres" ? true : false}"
-  option_group_name = "${local.default_option_and_parameter_group_name}"
   parameter_group_name = "${var.parameter_group_name != "" ? var.parameter_group_name : local.default_option_and_parameter_group_name}"
   port = "${local.is_postgres ? 5432 : 3306}"
   sg_on_rds_instance_name = "rds-${var.name}_${var.env}-${local.engine_nickname}"
@@ -26,17 +25,6 @@ resource "aws_db_parameter_group" "mod" {
   name = "${local.parameter_group_name}"
   family = "${local.family}"
   description = "${local.family} parameter group for ${var.name} ${var.env}"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_db_option_group" "mod" {
-  count = "${local.is_postgres ? 0 : 1}"
-  name = "${local.option_group_name}"
-  engine_name = "${local.engine}"
-  major_engine_version = "${local.major_engine_version}"
 
   lifecycle {
     create_before_destroy = true

--- a/aws/rds/__examples__/.planshots.txt
+++ b/aws/rds/__examples__/.planshots.txt
@@ -163,15 +163,6 @@ timezone:                                      <computed>
 username:                                      "rds-mysqladmin"
 vpc_security_group_ids.#:                      <computed>
 
-+ module.rds-mysql.aws_db_option_group.mod
-id:                                            <computed>
-arn:                                           <computed>
-engine_name:                                   "mysql"
-major_engine_version:                          "5.7"
-name:                                          "rds-mysql-production-mysql57"
-name_prefix:                                   <computed>
-option_group_description:                      "Managed by Terraform"
-
 + module.rds-mysql.aws_db_parameter_group.mod
 id:                                            <computed>
 arn:                                           <computed>
@@ -585,5 +576,5 @@ revoke_rules_on_delete:                        "false"
 tags.%:                                        "1"
 tags.Name:                                     "rds-sg-spec-postgres_production-pg"
 vpc_id:                                        "sg-spec-postgres"
-Plan: 26 to add, 0 to change, 0 to destroy.
+Plan: 25 to add, 0 to change, 0 to destroy.
 

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -2,7 +2,6 @@ locals {
   engine_nickname = "${local.is_postgres ? "pg" : "mysql"}"
   family = "${var.engine}${var.engine_version}"
   is_postgres = "${var.engine == "postgres" ? true : false}"
-  option_group_name = "${var.name}-${var.env}-${local.engine_nickname}${replace(var.engine_version, ".", "")}"
   parameter_group_name = "${var.parameter_group_name != "" ? var.parameter_group_name : "${var.name}-${var.env}-${local.engine_nickname}${replace(var.engine_version, ".", "")}"}"
   port = "${local.is_postgres ? 5432 : 3306}"
   sg_on_rds_instance_name = "rds-${var.name}_${var.env}-${local.engine_nickname}"
@@ -29,17 +28,6 @@ resource "aws_db_parameter_group" "mod" {
   name = "${local.parameter_group_name}"
   family = "${local.family}"
   description = "${local.family} parameter group for ${var.name} ${var.env}"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_db_option_group" "mod" {
-  count = "${local.is_postgres ? 0 : 1}"
-  name = "${local.option_group_name}"
-  engine_name = "${var.engine}"
-  major_engine_version = "${var.engine_version}"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Now that all of our RDS instances have been switched to use default DB option groups, this PR updates the RDS-related modules to no longer create the empty, unused option group.

As backup snapshots expire (and the previously-used option groups become unused), this will allow me to update users of the modules here to version 7eced9f, which will remove the unused option group from AWS.