### PR TITLE
Move health check matchers to optional variables for load balancer

### DIFF
--- a/aws/application_load_balancer/main.tf
+++ b/aws/application_load_balancer/main.tf
@@ -2,13 +2,11 @@ locals {
   access_logs_glacier_transition_days = 365
 
   http_deregistration_delay = 30
-  http_health_check_matcher = "200,301"
   http_health_check_timeout = 5
   http_port_for_instances   = 80
   http_port_for_listener    = 80
 
   https_deregistration_delay = 30
-  https_health_check_matcher = "200"
   https_health_check_timeout = 5
   https_port_for_instances   = 443
   https_port_for_listener    = 443
@@ -78,7 +76,7 @@ resource "aws_alb_target_group" "http_target_group" {
   vpc_id               = "${var.vpc_id}"
 
   health_check {
-    matcher  = "${local.http_health_check_matcher}"
+    matcher  = "${var.http_health_check_matcher}"
     path     = "${var.health_check_path}"
     port     = "${local.http_port_for_instances}"
     protocol = "HTTP"
@@ -122,7 +120,7 @@ resource "aws_alb_target_group" "https_target_group" {
   vpc_id               = "${var.vpc_id}"
 
   health_check {
-    matcher  = "${local.https_health_check_matcher}"
+    matcher  = "${var.https_health_check_matcher}"
     path     = "${var.health_check_path}"
     port     = "${local.https_port_for_instances}"
     protocol = "HTTPS"

--- a/aws/application_load_balancer/variables.tf
+++ b/aws/application_load_balancer/variables.tf
@@ -48,6 +48,16 @@ variable "health_check_path" {
   default     = "/healthz"
 }
 
+variable "http_health_check_matcher" {
+  description = "(Optional) Health check matcher for the HTTP target group. Default '200,301'."
+  default     = "200,301"
+}
+
+variable "https_health_check_matcher" {
+  description = "(Optional) Health check matcher for the HTTPS target group. Default '200'."
+  default     = "200"
+}
+
 variable "internal" {
   description = "(Optional) If true, the LB will be internal. Default false."
   default     = false


### PR DESCRIPTION
Enables specifying the health check matcher for application load balancers, to allow for load balancers like the ones created in https://github.com/tablexi/chef-repo/pull/2308, which accept 307 as a valid check (the app redirects to Google for authorization).