### PR TITLE
Add output target_group_arns for application_load_balancer

### DIFF
--- a/aws/__examples__/.planshots.txt
+++ b/aws/__examples__/.planshots.txt
@@ -36,6 +36,7 @@ unique_id:                                   <computed>
 + module.ec2.aws_instance.mod[0]
 id:                                          <computed>
 ami:                                         "ami-cfe4b2b0"
+arn:                                         <computed>
 associate_public_ip_address:                 "true"
 availability_zone:                           <computed>
 cpu_core_count:                              <computed>
@@ -76,6 +77,7 @@ vpc_security_group_ids.#:                    <computed>
 + module.ec2.aws_instance.mod[1]
 id:                                          <computed>
 ami:                                         "ami-cfe4b2b0"
+arn:                                         <computed>
 associate_public_ip_address:                 "true"
 availability_zone:                           <computed>
 cpu_core_count:                              <computed>

--- a/aws/application_load_balancer/outputs.tf
+++ b/aws/application_load_balancer/outputs.tf
@@ -2,6 +2,10 @@ output "dns_name" {
   value = "${module.load_balancer.dns_name}"
 }
 
+output "target_group_arns" {
+  value = ["${compact(concat(aws_alb_target_group.https_target_group.*.arn, aws_alb_target_group.http_target_group.*.arn))}"]
+}
+
 output "zone_id" {
   value = "${module.load_balancer.zone_id}"
 }

--- a/aws/ec2/__examples__/.planshots.txt
+++ b/aws/ec2/__examples__/.planshots.txt
@@ -19,6 +19,7 @@ unique_id:                                 <computed>
 + module.with-ami.aws_instance.mod[0]
 id:                                        <computed>
 ami:                                       "with-ami"
+arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
 cpu_core_count:                            <computed>
@@ -59,6 +60,7 @@ vpc_security_group_ids.#:                  <computed>
 + module.with-ami.aws_instance.mod[1]
 id:                                        <computed>
 ami:                                       "with-ami"
+arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
 cpu_core_count:                            <computed>
@@ -168,6 +170,7 @@ vpc:                                       "true"
 + module.with-eip.aws_instance.mod[0]
 id:                                        <computed>
 ami:                                       "ami-cfe4b2b0"
+arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
 cpu_core_count:                            <computed>
@@ -208,6 +211,7 @@ vpc_security_group_ids.#:                  <computed>
 + module.with-eip.aws_instance.mod[1]
 id:                                        <computed>
 ami:                                       "ami-cfe4b2b0"
+arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
 cpu_core_count:                            <computed>
@@ -295,6 +299,7 @@ type:                                      "ingress"
 + module.with-iam-instance-profile.aws_instance.mod[0]
 id:                                        <computed>
 ami:                                       "ami-cfe4b2b0"
+arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
 cpu_core_count:                            <computed>
@@ -336,6 +341,7 @@ vpc_security_group_ids.#:                  <computed>
 + module.with-iam-instance-profile.aws_instance.mod[1]
 id:                                        <computed>
 ami:                                       "ami-cfe4b2b0"
+arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
 cpu_core_count:                            <computed>
@@ -424,6 +430,7 @@ type:                                      "ingress"
 + module.without-ami.aws_instance.mod[0]
 id:                                        <computed>
 ami:                                       "ami-cfe4b2b0"
+arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
 cpu_core_count:                            <computed>
@@ -464,6 +471,7 @@ vpc_security_group_ids.#:                  <computed>
 + module.without-ami.aws_instance.mod[1]
 id:                                        <computed>
 ami:                                       "ami-cfe4b2b0"
+arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
 cpu_core_count:                            <computed>


### PR DESCRIPTION
This allows the ALBs created to be connected to auto scaling groups, which require ARNs of the target groups, so they know where to register instances as they bring them up.