### PR TITLE
Make AMI a required argument of aws/ec2 module

### DIFF
--- a/aws/__examples__/.planshots.txt
+++ b/aws/__examples__/.planshots.txt
@@ -35,7 +35,7 @@ unique_id:                                   <computed>
 
 + module.ec2.aws_instance.mod[0]
 id:                                          <computed>
-ami:                                         "ami-cfe4b2b0"
+ami:                                         "ami-0ff8a91507f77f867"
 arn:                                         <computed>
 associate_public_ip_address:                 "true"
 availability_zone:                           <computed>
@@ -76,7 +76,7 @@ vpc_security_group_ids.#:                    <computed>
 
 + module.ec2.aws_instance.mod[1]
 id:                                          <computed>
-ami:                                         "ami-cfe4b2b0"
+ami:                                         "ami-0ff8a91507f77f867"
 arn:                                         <computed>
 associate_public_ip_address:                 "true"
 availability_zone:                           <computed>
@@ -624,6 +624,7 @@ subnet_id:                                   "${element(aws_subnet.mod_public.*.
 
 + module.subnets.aws_subnet.mod_private[0]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1a"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -636,6 +637,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_private[1]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1b"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -648,6 +650,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_private[2]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1c"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -660,6 +663,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_private[3]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1d"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -672,6 +676,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_private[4]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1e"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -684,6 +689,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_private[5]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1f"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -696,6 +702,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_public[0]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1a"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -708,6 +715,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_public[1]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1b"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -720,6 +728,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_public[2]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1c"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -732,6 +741,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_public[3]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1d"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -744,6 +754,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_public[4]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1e"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -756,6 +767,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets.aws_subnet.mod_public[5]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1f"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"

--- a/aws/__examples__/integration.tf
+++ b/aws/__examples__/integration.tf
@@ -95,6 +95,7 @@ module "ssh" {
 module "ec2" {
   source = "../ec2"
 
+  ami = "ami-0ff8a91507f77f867"
   key_name = "ec2-key"
   name = "app"
   subnets = "${module.subnets.public_subnets}"

--- a/aws/ec2/__examples__/.planshots.txt
+++ b/aws/ec2/__examples__/.planshots.txt
@@ -169,7 +169,7 @@ vpc:                                       "true"
 
 + module.with-eip.aws_instance.mod[0]
 id:                                        <computed>
-ami:                                       "ami-cfe4b2b0"
+ami:                                       "ami-0ff8a91507f77f867"
 arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
@@ -210,7 +210,7 @@ vpc_security_group_ids.#:                  <computed>
 
 + module.with-eip.aws_instance.mod[1]
 id:                                        <computed>
-ami:                                       "ami-cfe4b2b0"
+ami:                                       "ami-0ff8a91507f77f867"
 arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
@@ -298,7 +298,7 @@ type:                                      "ingress"
 
 + module.with-iam-instance-profile.aws_instance.mod[0]
 id:                                        <computed>
-ami:                                       "ami-cfe4b2b0"
+ami:                                       "ami-0ff8a91507f77f867"
 arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
@@ -340,7 +340,7 @@ vpc_security_group_ids.#:                  <computed>
 
 + module.with-iam-instance-profile.aws_instance.mod[1]
 id:                                        <computed>
-ami:                                       "ami-cfe4b2b0"
+ami:                                       "ami-0ff8a91507f77f867"
 arn:                                       <computed>
 associate_public_ip_address:               "true"
 availability_zone:                         <computed>
@@ -426,134 +426,5 @@ self:                                      "false"
 source_security_group_id:                  <computed>
 to_port:                                   "22"
 type:                                      "ingress"
-
-+ module.without-ami.aws_instance.mod[0]
-id:                                        <computed>
-ami:                                       "ami-cfe4b2b0"
-arn:                                       <computed>
-associate_public_ip_address:               "true"
-availability_zone:                         <computed>
-cpu_core_count:                            <computed>
-cpu_threads_per_core:                      <computed>
-ebs_block_device.#:                        <computed>
-ebs_optimized:                             "false"
-ephemeral_block_device.#:                  <computed>
-get_password_data:                         "false"
-instance_state:                            <computed>
-instance_type:                             "t2.small"
-ipv6_address_count:                        <computed>
-ipv6_addresses.#:                          <computed>
-key_name:                                  "without-ami"
-network_interface.#:                       <computed>
-network_interface_id:                      <computed>
-password_data:                             <computed>
-placement_group:                           <computed>
-primary_network_interface_id:              <computed>
-private_dns:                               <computed>
-private_ip:                                <computed>
-public_dns:                                <computed>
-public_ip:                                 <computed>
-root_block_device.#:                       "1"
-root_block_device.0.delete_on_termination: "true"
-root_block_device.0.volume_id:             <computed>
-root_block_device.0.volume_size:           "16"
-root_block_device.0.volume_type:           "gp2"
-security_groups.#:                         <computed>
-source_dest_check:                         "true"
-subnet_id:                                 "without-ami"
-tags.%:                                    "2"
-tags.Environment:                          "production"
-tags.Name:                                 "without-ami01"
-tenancy:                                   <computed>
-volume_tags.%:                             <computed>
-vpc_security_group_ids.#:                  <computed>
-
-+ module.without-ami.aws_instance.mod[1]
-id:                                        <computed>
-ami:                                       "ami-cfe4b2b0"
-arn:                                       <computed>
-associate_public_ip_address:               "true"
-availability_zone:                         <computed>
-cpu_core_count:                            <computed>
-cpu_threads_per_core:                      <computed>
-ebs_block_device.#:                        <computed>
-ebs_optimized:                             "false"
-ephemeral_block_device.#:                  <computed>
-get_password_data:                         "false"
-instance_state:                            <computed>
-instance_type:                             "t2.small"
-ipv6_address_count:                        <computed>
-ipv6_addresses.#:                          <computed>
-key_name:                                  "without-ami"
-network_interface.#:                       <computed>
-network_interface_id:                      <computed>
-password_data:                             <computed>
-placement_group:                           <computed>
-primary_network_interface_id:              <computed>
-private_dns:                               <computed>
-private_ip:                                <computed>
-public_dns:                                <computed>
-public_ip:                                 <computed>
-root_block_device.#:                       "1"
-root_block_device.0.delete_on_termination: "true"
-root_block_device.0.volume_id:             <computed>
-root_block_device.0.volume_size:           "16"
-root_block_device.0.volume_type:           "gp2"
-security_groups.#:                         <computed>
-source_dest_check:                         "true"
-subnet_id:                                 "without-ami"
-tags.%:                                    "2"
-tags.Environment:                          "production"
-tags.Name:                                 "without-ami02"
-tenancy:                                   <computed>
-volume_tags.%:                             <computed>
-vpc_security_group_ids.#:                  <computed>
-
-+ module.without-ami.aws_security_group.security_group_on_instances
-id:                                        <computed>
-arn:                                       <computed>
-description:                               "Managed by Terraform"
-egress.#:                                  <computed>
-ingress.#:                                 <computed>
-name:                                      "without-ami-ec2-instances"
-owner_id:                                  <computed>
-revoke_rules_on_delete:                    "false"
-tags.%:                                    "1"
-tags.Name:                                 "without-ami-ec2-instances"
-vpc_id:                                    "vpc_abc123"
-
-+ module.without-ami.aws_security_group_rule.all_egress_on_instances_to_anywhere
-id:                                        <computed>
-cidr_blocks.#:                             "1"
-cidr_blocks.0:                             "0.0.0.0/0"
-from_port:                                 "0"
-protocol:                                  "-1"
-security_group_id:                         "${aws_security_group.security_group_on_instances.id}"
-self:                                      "false"
-source_security_group_id:                  <computed>
-to_port:                                   "0"
-type:                                      "egress"
-
-+ module.without-ami.aws_security_group_rule.all_ingress_on_instances_from_self
-id:                                        <computed>
-from_port:                                 "0"
-protocol:                                  "-1"
-security_group_id:                         "${aws_security_group.security_group_on_instances.id}"
-self:                                      "true"
-source_security_group_id:                  <computed>
-to_port:                                   "0"
-type:                                      "ingress"
-
-+ module.without-ami.aws_security_group_rule.ssh_ingress_on_instances_from_anywhere
-id:                                        <computed>
-cidr_blocks.#:                             "1"
-cidr_blocks.0:                             "0.0.0.0/0"
-from_port:                                 "22"
-protocol:                                  "tcp"
-security_group_id:                         "${aws_security_group.security_group_on_instances.id}"
-self:                                      "false"
-source_security_group_id:                  <computed>
-to_port:                                   "22"
-type:                                      "ingress"
-Plan: 27 to add, 0 to change, 0 to destroy.
+Plan: 21 to add, 0 to change, 0 to destroy.
 

--- a/aws/ec2/__examples__/basic.tf
+++ b/aws/ec2/__examples__/basic.tf
@@ -1,12 +1,3 @@
-module "without-ami" {
-  source = "../"
-
-  key_name = "without-ami"
-  name = "without-ami"
-  subnets = ["without-ami"]
-  vpc_id = "vpc_abc123"
-}
-
 module "with-ami" {
   source = "../"
 

--- a/aws/ec2/__examples__/eip.tf
+++ b/aws/ec2/__examples__/eip.tf
@@ -1,6 +1,7 @@
 module "with-eip" {
   source = "../"
 
+  ami = "ami-0ff8a91507f77f867"
   enable_eip = true
   key_name = "without-ami"
   name = "without-ami"

--- a/aws/ec2/__examples__/iam_instance_profile.tf
+++ b/aws/ec2/__examples__/iam_instance_profile.tf
@@ -5,6 +5,7 @@ resource "aws_iam_instance_profile" "with-iam-instance-profile" {
 module "with-iam-instance-profile" {
   source = "../"
 
+  ami = "ami-0ff8a91507f77f867"
   iam_instance_profile = "${aws_iam_instance_profile.with-iam-instance-profile.arn}"
   key_name = "without-ami"
   name = "without-ami"

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -1,16 +1,6 @@
-data "aws_ami" "mod" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-hvm-*x86_64-gp2"]
-  }
-}
-
 resource "aws_instance" "mod" {
   count                       = "${var.count}"
-  ami                         = "${var.ami != "" ? var.ami : data.aws_ami.mod.id}"
+  ami                         = "${var.ami}"
   instance_type               = "${var.type}"
   key_name                    = "${var.key_name}"
   vpc_security_group_ids      = ["${aws_security_group.security_group_on_instances.id}", "${var.vpc_security_group_ids}"]

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -3,7 +3,7 @@ variable "associate_public_ip_address" {
 }
 
 variable "ami" {
-  default = ""
+  description = "(Required) The AMI to use for the instance."
 }
 
 variable "count" {

--- a/aws/vpc/subnets/__examples__/.planshots.txt
+++ b/aws/vpc/subnets/__examples__/.planshots.txt
@@ -108,6 +108,7 @@ subnet_id:                                   "${element(aws_subnet.mod_public.*.
 
 + module.subnets_test1.aws_subnet.mod_private[0]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1a"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -120,6 +121,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_private[1]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1b"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -132,6 +134,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_private[2]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1c"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -144,6 +147,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_private[3]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1d"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -156,6 +160,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_private[4]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1e"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -168,6 +173,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_private[5]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1f"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.private_newbits, var.private_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -180,6 +186,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_public[0]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1a"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -192,6 +199,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_public[1]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1b"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -204,6 +212,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_public[2]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1c"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -216,6 +225,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_public[3]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1d"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -228,6 +238,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_public[4]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1e"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"
@@ -240,6 +251,7 @@ vpc_id:                                      "${var.vpc_id}"
 
 + module.subnets_test1.aws_subnet.mod_public[5]
 id:                                          <computed>
+arn:                                         <computed>
 assign_ipv6_address_on_creation:             "false"
 availability_zone:                           "us-east-1f"
 cidr_block:                                  "${cidrsubnet(data.aws_vpc.current.cidr_block, var.public_newbits, var.public_netnum_offset + element(data.template_file.az_to_netnum.*.rendered, count.index))}"


### PR DESCRIPTION
This PR makes AMI a required argument when using `//aws/ec2`, removing the existing default which pulls in the latest AMI published at the time of evaluation.

With the default in place, Terraform checks the list of published AMIs on every refresh, which causes a dirty plan when Amazon publishes a new AMI, which is beyond our control. I believe that requiring the AMI (just like Terraform’s `aws_instance`does) is a better approach that leads to fewer surprises—by failing unless a user of this module specifies an `ami`, the onus is on the user to pick an AMI that is appropriate, and the module will not cause any dirty plans on its own.