### PR TITLE
Make ingress_cidr_blocks and ingress_security_groups variables for ALB

### DIFF
--- a/aws/application_load_balancer/main.tf
+++ b/aws/application_load_balancer/main.tf
@@ -23,17 +23,19 @@ resource "aws_security_group" "security_group_on_load_balancer" {
   vpc_id = "${var.vpc_id}"
 
   ingress {
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = "${local.http_listener_port}"
-    protocol    = "tcp"
-    to_port     = "${local.http_listener_port}"
+    cidr_blocks     = ["${var.ingress_cidr_blocks}"]
+    from_port       = "${local.http_listener_port}"
+    protocol        = "tcp"
+    security_groups = ["${var.ingress_security_groups}"]
+    to_port         = "${local.http_listener_port}"
   }
 
   ingress {
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = "${local.https_listener_port}"
-    protocol    = "tcp"
-    to_port     = "${local.https_listener_port}"
+    cidr_blocks     = ["${var.ingress_cidr_blocks}"]
+    from_port       = "${local.https_listener_port}"
+    protocol        = "tcp"
+    security_groups = ["${var.ingress_security_groups}"]
+    to_port         = "${local.https_listener_port}"
   }
 
   egress {

--- a/aws/application_load_balancer/variables.tf
+++ b/aws/application_load_balancer/variables.tf
@@ -63,6 +63,16 @@ variable "https_target_group" {
   default     = true
 }
 
+variable "ingress_cidr_blocks" {
+  description = "(Optional) List of CIDR blocks that can access the load balancer."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "ingress_security_groups" {
+  description = "(Optional) List of security group IDs that can access the load balancer."
+  default     = []
+}
+
 variable "internal" {
   description = "(Optional) If true, the LB will be internal. Default false."
   default     = false


### PR DESCRIPTION
Allows controlling ingress for a load balancer, so we don’t always have to accept traffic from the entire world.