### PR TITLE
Create a replacement SG on EC2 instances before destroying

### DIFF
--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -35,6 +35,10 @@ resource "aws_security_group" "security_group_on_instances" {
   name   = "${var.name}-ec2-instances"
   vpc_id = "${var.vpc_id}"
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags {
     "Name" = "${var.name}-ec2-instances"
   }


### PR DESCRIPTION
When the name of the security group that is associated with EC2 instances needs to change, Terraform must do a destroy/create cyle. Without this, it tries to destroy the existing security group first, which fails because it is still associated with the EC2 instances.

Hopefully, this specification gets around the problem.