### PR TITLE
Use <<- instead of <<~ for heredoc

### DIFF
--- a/aws/iam/s3/full/main.tf
+++ b/aws/iam/s3/full/main.tf
@@ -1,28 +1,28 @@
 resource "aws_iam_policy" "mod" {
   name = "S3${var.name}${var.env}Access"
 
-  policy = <<~EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Action": [
-          "s3:ListAllMyBuckets"
-        ],
-        "Effect": "Allow",
-        "Resource": "arn:aws:s3:::*"
-      },
-      {
-        "Action": "s3:*",
-        "Effect": "Allow",
-        "Resource": [
-          "arn:aws:s3:::${var.bucket_id}",
-          "arn:aws:s3:::${var.bucket_id}/*"
-        ]
-      }
-    ]
-  }
-  EOF
+  policy = <<-EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "s3:ListAllMyBuckets"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:s3:::*"
+        },
+        {
+          "Action": "s3:*",
+          "Effect": "Allow",
+          "Resource": [
+            "arn:aws:s3:::${var.bucket_id}",
+            "arn:aws:s3:::${var.bucket_id}/*"
+          ]
+        }
+      ]
+    }
+    EOF
 }
 
 resource "aws_iam_policy_attachment" "mod" {


### PR DESCRIPTION
As-is, running `terraform fmt` on the file results in:

```
$ terraform fmt aws/iam/s3/full/main.tf 
Error running fmt: In aws/iam/s3/full/main.tf: At 6:14: illegal char
```

Terraform’s support for removing leading indentation in heredocs [uses `<<-`](https://github.com/hashicorp/hcl/pull/91/commits/f5480db646fc904bd29f10187279560131c0d639), and it does not support Ruby’s `<<~`, so this PR updates accordingly.