### PR TITLE
UPDATE s3 bucket name to match new requirements

### DIFF
--- a/aws/terraform_config/main.tf
+++ b/aws/terraform_config/main.tf
@@ -1,7 +1,7 @@
 provider "aws" {}
 
 resource "aws_s3_bucket" "mod" {
-  bucket = "${var.name}_tf"
+  bucket = "${var.name}-tf"
 
   tags {
     Name = "${var.name} terraform configutation"


### PR DESCRIPTION
We can no longer use `_` in bucket names. See https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html section on "Legacy Non-DNS-Compliant Bucket Names"