### PR TITLE
ADD ability to set a specific KMS key for rds instances

### DIFF
--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -54,6 +54,7 @@ resource "aws_db_instance" "mod" {
   final_snapshot_identifier   = "${var.name}-${var.env}-${var.engine}-final-snapshot"
   skip_final_snapshot         = "${var.skip_final_snapshot}"
   storage_encrypted           = "${var.storage_encrypted}"
+  kms_key_id                  = "${var.kms_key_id}"
   publicly_accessible         = "${var.publicly_accessible}"
   auto_minor_version_upgrade  = "${var.auto_minor_version_upgrade}"
   allow_major_version_upgrade = true

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -35,6 +35,11 @@ variable "identifier" {
   default     = ""
 }
 
+variable "kms_key_id" {
+  description = "If you are using volume encryption, you can use this variable to set the specific key arn."
+  default = ""
+}
+
 variable "multi_az" {
   description = "AWS RDS automatically creates a primary DB Instance and synchronously replicates the data to a standby instance in a different Availability Zone."
   default     = true

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -37,7 +37,7 @@ variable "identifier" {
 
 variable "kms_key_id" {
   description = "If you are using volume encryption, you can use this variable to set the specific key arn."
-  default = ""
+  default     = ""
 }
 
 variable "multi_az" {


### PR DESCRIPTION
If you use the var `storage_encryption`, you currently cannot set the specific KMS key to use.