### PR TITLE
Add output for https listener arn

### DIFF
--- a/aws/application_load_balancer/outputs.tf
+++ b/aws/application_load_balancer/outputs.tf
@@ -9,3 +9,7 @@ output "target_group_arns" {
 output "zone_id" {
   value = "${module.load_balancer.zone_id}"
 }
+
+output "https_listener_arn" {
+  value = "${aws_alb_listener.https_listener.arn}"
+}


### PR DESCRIPTION
On pk we're trying to add a second cert to the elb but unable to because we're not able to reference the  `https_listener` resource since it's defined inside the `application_load_balance` module and not exposed. This PR exposes the `https_ listener.arn` via an output.