### PR TITLE
Set apply_immediately on aws/elasticache to avoid surprises

### DIFF
--- a/aws/elasticache/main.tf
+++ b/aws/elasticache/main.tf
@@ -11,6 +11,7 @@ locals {
 }
 
 resource "aws_elasticache_cluster" "mod" {
+  apply_immediately    = true
   count                = "${local.elasticache_replication_group ? 0 : 1}"
   cluster_id           = "${local.cluster_name}"
   num_cache_nodes      = 1


### PR DESCRIPTION
Currently changes to `node_type` apply in Terraform, but do not take effect until the next maintenance window, which is confusing and not what we want most of the time.