### PR TITLE
Stop creating empty RDS Parameter Groups

### DIFF
--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -38,13 +38,8 @@ variable "node_type" {
 }
 
 variable "parameter_group_name" {
-  description = "Name of a parameter group to use with the RDS instance."
+  description = "Name of a parameter group to use with the RDS instance instead of the default."
   default     = ""
-}
-
-variable "parameter_group_provided" {
-  description = "If the parameter_group_name is provided, must be set to true."
-  default     = false
 }
 
 variable "publicly_accessible" {

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -2,7 +2,8 @@ locals {
   engine_nickname         = "${local.is_postgres ? "pg" : "mysql"}"
   family                  = "${var.engine}${var.engine_version}"
   is_postgres             = "${var.engine == "postgres" ? true : false}"
-  parameter_group_name    = "${var.parameter_group_name != "" ? var.parameter_group_name : "${var.name}-${var.env}-${local.engine_nickname}${replace(var.engine_version, ".", "")}"}"
+  major_engine_version    = "${join(".", slice(split(".", var.engine_version), 0, 2))}"
+  parameter_group_name    = "${var.parameter_group_name != "" ? var.parameter_group_name : "default.${var.engine}${local.major_engine_version}"}"
   port                    = "${local.is_postgres ? 5432 : 3306}"
   sg_on_rds_instance_name = "rds-${var.name}_${var.env}-${local.engine_nickname}"
   subnet_group_name       = "${var.subnet_group_name != "" ? var.subnet_group_name : "${var.name}-${var.env}-${local.engine_nickname}-sg"}"
@@ -21,17 +22,6 @@ resource "aws_db_subnet_group" "mod" {
     # though the AWS documentation says otherwise.
     # http://serverfault.com/a/817598
     ignore_changes = ["name"]
-  }
-}
-
-resource "aws_db_parameter_group" "mod" {
-  count       = "${var.parameter_group_provided ? 0 : 1}"
-  name        = "${local.parameter_group_name}"
-  family      = "${local.family}"
-  description = "${local.family} parameter group for ${var.name} ${var.env}"
-
-  lifecycle {
-    create_before_destroy = true
   }
 }
 

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -50,13 +50,8 @@ variable "node_type" {
 }
 
 variable "parameter_group_name" {
-  description = "Name of a parameter group to use with the RDS instance."
+  description = "Name of a parameter group to use with the RDS instance instead of the default."
   default     = ""
-}
-
-variable "parameter_group_provided" {
-  description = "If the parameter_group_name is provided, must be set to true."
-  default     = false
 }
 
 variable "publicly_accessible" {


### PR DESCRIPTION
This PR still allows specifying a `parameter_group_name` for an RDS instance (in both the stand-alone and replica modules), but it stops creating an empty parameter group when one is not specified — we just use the default in those cases.