### PR TITLE
Support redirect_http_to_https in aws/application_load_balancer

### DIFF
--- a/aws/application_load_balancer/main.tf
+++ b/aws/application_load_balancer/main.tf
@@ -57,6 +57,7 @@ resource "aws_alb_listener" "http_listener" {
 resource "aws_alb_listener_rule" "redirect_http_to_https" {
   count        = "${var.redirect_http_to_https ? 1 : 0}"
   listener_arn = "${aws_alb_listener.http_listener.arn}"
+  priority     = 1000
 
   action {
     type = "redirect"

--- a/aws/application_load_balancer/main.tf
+++ b/aws/application_load_balancer/main.tf
@@ -54,6 +54,26 @@ resource "aws_alb_listener" "http_listener" {
   }
 }
 
+resource "aws_alb_listener_rule" "redirect_http_to_https" {
+  count        = "${var.redirect_http_to_https ? 1 : 0}"
+  listener_arn = "${aws_alb_listener.http_listener.arn}"
+
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "${var.redirect_http_to_https_status_code}"
+    }
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["*"]
+  }
+}
+
 resource "aws_alb_target_group" "http_target_group" {
   deregistration_delay = 30
   name                 = "${local.prefix}-http"

--- a/aws/application_load_balancer/outputs.tf
+++ b/aws/application_load_balancer/outputs.tf
@@ -10,6 +10,10 @@ output "zone_id" {
   value = "${module.load_balancer.zone_id}"
 }
 
+output "http_listener_arn" {
+  value = "${aws_alb_listener.http_listener.arn}"
+}
+
 output "https_listener_arn" {
   value = "${aws_alb_listener.https_listener.arn}"
 }

--- a/aws/application_load_balancer/variables.tf
+++ b/aws/application_load_balancer/variables.tf
@@ -88,6 +88,16 @@ variable "internal" {
   default     = false
 }
 
+variable "redirect_http_to_https" {
+  description = "(Optional) If true, the HTTP listener will redirect to HTTPS. Default false."
+  default     = false
+}
+
+variable "redirect_http_to_https_status_code" {
+  description = "(Optional) If redirect_http_to_https is true, the HTTP status code that will be used for the redirect. Default HTTP_301."
+  default     = "HTTP_301"
+}
+
 variable "ssl_policy" {
   description = "(Optional) The name of the SSL Policy for the HTTPS listener. Default ELBSecurityPolicy-TLS-1-2-2017-01."
   default     = "ELBSecurityPolicy-TLS-1-2-2017-01"


### PR DESCRIPTION
Allows specifying `redirect_http_to_https = true` to have the application load balancer perform HTTP to HTTPS redirects, relieving nginx and/or the application server of these duties.

The default redirect is a 301, but it is possible to change this with the parameter `redirect_http_to_https_status_code`.