### PR TITLE
Point HTTPS listener to HTTP target group in ALB

### DIFF
--- a/aws/application_load_balancer/main.tf
+++ b/aws/application_load_balancer/main.tf
@@ -93,7 +93,7 @@ resource "aws_alb_listener" "https_listener" {
   ssl_policy        = "${var.ssl_policy}"
 
   default_action {
-    target_group_arn = "${var.https_target_group ? element(concat(aws_alb_target_group.https_target_group.*.arn, list("")), 0) : aws_alb_target_group.http_target_group.arn}"
+    target_group_arn = "${aws_alb_target_group.http_target_group.arn}"
     type             = "forward"
   }
 }


### PR DESCRIPTION
In support of removing HTTPS configuration from nginx, and serving only HTTP from the EC2 instances, this PR makes the HTTPS listener in our application load balancers forward to the HTTP target group.

I did not remove the unused HTTPS target groups in this PR just yet, to allow for a quick rollback in case something goes wrong — this way, we can just point to the HTTPS target group without having to recreate it, and when we’re satisfied that everything works well after a while, I’ll clean up the unused resources.