### PR TITLE
Break EKS setup into two parts

### DIFF
--- a/aws/eks/master/main.tf
+++ b/aws/eks/master/main.tf
@@ -88,27 +88,3 @@ resource "aws_eks_cluster" "master" {
     "aws_iam_role_policy_attachment.eks_service_role_service_policy",
   ]
 }
-
-# Worker Nodes
-
-resource "aws_cloudformation_stack" "nodes" {
-  capabilities = ["CAPABILITY_IAM"]
-  name         = "${var.name}"
-  template_url = "https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2019-01-09/amazon-eks-nodegroup.yaml"
-
-  parameters {
-    ClusterControlPlaneSecurityGroup    = "${aws_security_group.master.id}"
-    ClusterName                         = "${var.name}"
-    KeyName                             = "${var.key_name}"
-    NodeAutoScalingGroupDesiredCapacity = 3
-    NodeAutoScalingGroupMaxSize         = 6
-    NodeAutoScalingGroupMinSize         = 3
-    NodeGroupName                       = "${var.name}"
-    NodeImageId                         = "ami-0c5b63ec54dd3fc38"
-    NodeInstanceType                    = "t2.medium"
-    Subnets                             = "${join(",", module.eks-subnets.subnets)}"
-    VpcId                               = "${module.eks-vpc.vpc_id}"
-  }
-
-  tags = "${local.tags}"
-}

--- a/aws/eks/master/main.tf
+++ b/aws/eks/master/main.tf
@@ -9,12 +9,12 @@ locals {
 }
 
 module "eks-vpc" {
-  source = "../vpc"
+  source = "../../vpc"
   tags   = "${local.tags}"
 }
 
 module "eks-subnets" {
-  source = "../vpc/subnets"
+  source = "../../vpc/subnets"
 
   internet_gateway_id = "${module.eks-vpc.internet_gateway_id}"
   tags                = "${local.tags}"

--- a/aws/eks/master/outputs.tf
+++ b/aws/eks/master/outputs.tf
@@ -1,0 +1,11 @@
+output "master_security_group_id" {
+  value = "${aws_security_group.master.id}"
+}
+
+output "subnets" {
+  value = "${module.eks-subnets.subnets}"
+}
+
+output "vpc_id" {
+  value = "${module.eks-vpc.vpc_id}"
+}

--- a/aws/eks/master/variables.tf
+++ b/aws/eks/master/variables.tf
@@ -1,5 +1,3 @@
-variable "key_name" {}
-
 variable "name" {
   description = "Name of the cluster"
 }

--- a/aws/eks/nodes/main.tf
+++ b/aws/eks/nodes/main.tf
@@ -1,0 +1,29 @@
+locals {
+  default_tags = {
+    Name = "${var.name}"
+  }
+
+  tags = "${merge(local.default_tags, var.tags)}"
+}
+
+resource "aws_cloudformation_stack" "nodes" {
+  capabilities = ["CAPABILITY_IAM"]
+  name         = "${var.name}"
+  template_url = "https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2019-01-09/amazon-eks-nodegroup.yaml"
+
+  parameters {
+    ClusterControlPlaneSecurityGroup    = "${var.master_security_group_id}"
+    ClusterName                         = "${var.name}"
+    KeyName                             = "${var.key_name}"
+    NodeAutoScalingGroupDesiredCapacity = "${var.capacity_desired}"
+    NodeAutoScalingGroupMaxSize         = "${var.capacity_max}"
+    NodeAutoScalingGroupMinSize         = "${var.capacity_min}"
+    NodeGroupName                       = "${var.name}"
+    NodeImageId                         = "${var.ami}"
+    NodeInstanceType                    = "${var.instance_type}"
+    Subnets                             = "${join(",", var.subnets)}"
+    VpcId                               = "${var.vpc_id}"
+  }
+
+  tags = "${local.tags}"
+}

--- a/aws/eks/nodes/outputs.tf
+++ b/aws/eks/nodes/outputs.tf
@@ -1,0 +1,3 @@
+output "node_instance_role" {
+  value = "${aws_cloudformation_stack.nodes.outputs["NodeInstanceRole"]}"
+}

--- a/aws/eks/nodes/variables.tf
+++ b/aws/eks/nodes/variables.tf
@@ -4,7 +4,7 @@ variable "ami" {
 }
 
 variable "instance_type" {
-  default = "t2.medium"
+  default = "t3.medium"
 }
 
 variable "subnets" {

--- a/aws/eks/nodes/variables.tf
+++ b/aws/eks/nodes/variables.tf
@@ -18,7 +18,7 @@ variable "vpc_id" {
 
 variable "master_security_group_id" {
   description = "Security group id from the master control plane"
-  type        = "map"
+  type        = "string"
 }
 
 variable "capacity_min" {

--- a/aws/eks/nodes/variables.tf
+++ b/aws/eks/nodes/variables.tf
@@ -1,0 +1,48 @@
+variable "ami" {
+  description = "AMI used to build each node"
+  default     = "ami-0c5b63ec54dd3fc38"
+}
+
+variable "instance_type" {
+  default = "t2.medium"
+}
+
+variable "subnets" {
+  description = "The subnet ids to create nodes in"
+  type        = "list"
+}
+
+variable "vpc_id" {
+  description = "The id of the VPC to create nodes in"
+}
+
+variable "master_security_group_id" {
+  description = "Security group id from the master control plane"
+  type        = "map"
+}
+
+variable "capacity_min" {
+  description = "Minimum number of nodes to create"
+  default     = 3
+}
+
+variable "capacity_desired" {
+  description = "Desired number of nodes to create"
+  default     = 3
+}
+
+variable "capacity_max" {
+  description = "Maximum number of nodes to create"
+  default     = 6
+}
+
+variable "key_name" {}
+
+variable "name" {
+  description = "Name of the cluster"
+}
+
+variable "tags" {
+  description = "(Optional) A mapping of tags to assign to the resources"
+  type        = "map"
+}


### PR DESCRIPTION
This is required because if you build the nodes before the master is available then they do not ever register