### PR TITLE
Support redirecting domains in ALB

### DIFF
--- a/aws/application_load_balancer/variables.tf
+++ b/aws/application_load_balancer/variables.tf
@@ -88,6 +88,11 @@ variable "internal" {
   default     = false
 }
 
+variable "redirect_domains" {
+  description = "(Optional) Map of domains to redirect. Keys are domains to redirect from, and values are domains to redirect to. Default {}."
+  default     = {}
+}
+
 variable "redirect_http_to_https" {
   description = "(Optional) If true, the HTTP listener will redirect to HTTPS. Default false."
   default     = false


### PR DESCRIPTION
Supports redirecting domains from an ALB response directly by specifying the `redirect_domains` argument:

```
redirect_domains {
  "mysite.com" = "www.mysite.com"
}
```

would make the ALB redirect requests for `mysite.com`, to `www.mysite.com`.