### PR TITLE
Remove ability to specify a different region in //aws/database_replica

### DIFF
--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -1,16 +1,5 @@
-provider "aws" {
-  alias  = "source_region"
-  region = "${var.source_db_region}"
-}
-
-provider "aws" {
-  region = "${var.replica_db_region}"
-}
-
 data "aws_db_instance" "source_database" {
   db_instance_identifier = "${var.source_db}"
-
-  provider = "aws.source_region"
 }
 
 locals {
@@ -24,36 +13,36 @@ locals {
   parameter_group_name    = "${var.parameter_group_name != "" ? var.parameter_group_name : "default.${local.engine}${local.major_engine_version}"}"
   port                    = "${local.is_postgres ? 5432 : 3306}"
   sg_on_rds_instance_name = "rds-${var.name}_${var.env}-${local.engine_nickname}"
-  source_db               = "${var.replica_db_region == var.source_db_region ? data.aws_db_instance.source_database.id : data.aws_db_instance.source_database.db_instance_arn}"
+  source_db               = "${data.aws_db_instance.source_database.id}"
   storage_encrypted       = "${data.aws_db_instance.source_database.storage_encrypted}"
   storage_type            = "${data.aws_db_instance.source_database.storage_type}"
 }
 
 resource "aws_db_instance" "mod" {
-  identifier                  = "${var.identifier != "" ? var.identifier : "${var.name}-${var.env}-${local.engine}"}"
-  replicate_source_db         = "${local.source_db}"
-  engine                      = "${local.engine}"
-  engine_version              = "${local.engine_version}"
-  instance_class              = "${var.node_type}"
-  storage_type                = "${local.storage_type}"
   allocated_storage           = "${local.allocated_storage}"
-  backup_retention_period     = "${var.backup_retention_period}"
-  multi_az                    = "${var.multi_az}"
-  vpc_security_group_ids      = ["${concat(var.vpc_security_group_ids, list(aws_security_group.sg_on_rds_instance.id))}"]
-  parameter_group_name        = "${local.parameter_group_name}"
-  option_group_name           = "${"default:${local.engine}-${replace(local.major_engine_version, ".", "-")}"}"
-  final_snapshot_identifier   = "${var.name}-${var.env}-${local.engine}-final-snapshot"
-  skip_final_snapshot         = "${var.skip_final_snapshot}"
-  storage_encrypted           = "${local.storage_encrypted}"
-  publicly_accessible         = "${var.publicly_accessible}"
-  auto_minor_version_upgrade  = "${var.auto_minor_version_upgrade}"
   allow_major_version_upgrade = true
   apply_immediately           = true
+  auto_minor_version_upgrade  = "${var.auto_minor_version_upgrade}"
+  backup_retention_period     = "${var.backup_retention_period}"
+  engine                      = "${local.engine}"
+  engine_version              = "${local.engine_version}"
+  final_snapshot_identifier   = "${var.name}-${var.env}-${local.engine}-final-snapshot"
+  identifier                  = "${var.identifier != "" ? var.identifier : "${var.name}-${var.env}-${local.engine}"}"
+  instance_class              = "${var.node_type}"
+  multi_az                    = "${var.multi_az}"
+  option_group_name           = "${"default:${local.engine}-${replace(local.major_engine_version, ".", "-")}"}"
+  parameter_group_name        = "${local.parameter_group_name}"
+  publicly_accessible         = "${var.publicly_accessible}"
+  replicate_source_db         = "${local.source_db}"
+  skip_final_snapshot         = "${var.skip_final_snapshot}"
+  storage_encrypted           = "${local.storage_encrypted}"
+  storage_type                = "${local.storage_type}"
+  vpc_security_group_ids      = ["${concat(var.vpc_security_group_ids, list(aws_security_group.sg_on_rds_instance.id))}"]
 }
 
 resource "aws_security_group" "sg_on_rds_instance" {
-  name        = "${local.sg_on_rds_instance_name}"
   description = "${local.sg_on_rds_instance_name}"
+  name        = "${local.sg_on_rds_instance_name}"
   vpc_id      = "${var.vpc_id}"
 
   ingress {

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -57,24 +57,13 @@ variable "cidr_blocks_for_ingress" {
   default     = []
 }
 
-variable "replica_db_region" {
-  description = "AWS region to put the replica db"
-  default     = "us-east-1"
-}
-
 variable "skip_final_snapshot" {
   description = "Skip final snapshot before destroying instance."
   default     = true
 }
 
 variable "source_db" {
-  description = "recplication source db"
-  default     = ""
-}
-
-variable "source_db_region" {
-  description = "replication source db provider specification for cross region replication"
-  default     = "us-east-1"
+  description = "Source database identifier."
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
Having to specify providers in the module (so we can use a different region) caused problems when trying to delete a replica — Terraform’s explicit provider support requires that all providers be specified explicitly when they are configured in a module, so uses of this module that did not do that could not be deleted.

Since this feature is not used anywhere anymore, per Lloyd, it’s easiest to remove it.

Fixes #106 