### PR TITLE
no sub-module providers

### DIFF
--- a/aws/terraform_config/main.tf
+++ b/aws/terraform_config/main.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "mod" {
   bucket = "${var.name}${var.splitter}tf"
+  region = "${var.region}"
 
   tags {
     Name = "${var.name} terraform configuration"

--- a/aws/terraform_config/main.tf
+++ b/aws/terraform_config/main.tf
@@ -1,5 +1,3 @@
-provider "aws" {}
-
 resource "aws_s3_bucket" "mod" {
   bucket = "${var.name}${var.splitter}tf"
 

--- a/aws/terraform_config/variables.tf
+++ b/aws/terraform_config/variables.tf
@@ -1,4 +1,9 @@
-variable "name" {}
+variable "name" {
+}
+
+variable "region" {
+  default = "us-east-1"
+}
 
 variable "splitter" {
   default     = "-"

--- a/aws/terraform_config/variables.tf
+++ b/aws/terraform_config/variables.tf
@@ -1,5 +1,4 @@
-variable "name" {
-}
+variable "name" {}
 
 variable "region" {
   default = "us-east-1"


### PR DESCRIPTION
According to https://www.terraform.io/docs/configuration/modules.html#providers-within-modules:

> "While in principle provider blocks can appear in any module, it is recommended that they be placed only in the root module of a configuration, since this approach allows users to configure providers just once and re-use them across all descendent modules."

In eliminating this provider definition, I am able to specify the region in the provider block in `chef-repo/terraform/*/main.tf` and have that region take effect.

I believe that the empty `aws {}` provider block was likely added in relation to this PR dialogue: https://github.com/terraform-providers/terraform-provider-aws/issues/1043