### PR TITLE
REVERT default region of us-east-1 in terraform_config; use providers…

### DIFF
--- a/aws/terraform_config/main.tf
+++ b/aws/terraform_config/main.tf
@@ -1,6 +1,5 @@
 resource "aws_s3_bucket" "mod" {
   bucket = "${var.name}${var.splitter}tf"
-  region = "${var.region}"
 
   tags {
     Name = "${var.name} terraform configuration"

--- a/aws/terraform_config/variables.tf
+++ b/aws/terraform_config/variables.tf
@@ -1,9 +1,5 @@
 variable "name" {}
 
-variable "region" {
-  default = "us-east-1"
-}
-
 variable "splitter" {
   default     = "-"
   description = "This is around for legacy setups where we used an _ instead of -."


### PR DESCRIPTION
Turns out we can pass providers; so we don't need to default to us-east-1 and instead can rely on the region of the provider passed into the module:

https://www.terraform.io/docs/configuration/modules.html#passing-providers-explicitly

```
# terraform/CLIENT/main.tf
provider "aws" {
  region  = "us-west-2"
  version = "~> 2.2.0"
}

provider "aws" {
  alias   = "east"
  region  = "us-east-1"
  version = "~> 2.2.0"
}

# terraform/CLIENT/s3.tf
module "s3_terraform" {
  source   = "..."
  providers = {
    aws = "aws.east"
  }
}
```