### PR TITLE
Support iops for rds instances and replicas

### DIFF
--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -15,7 +15,7 @@ locals {
   sg_on_rds_instance_name = "rds-${var.name}_${var.env}-${local.engine_nickname}"
   source_db               = "${data.aws_db_instance.source_database.id}"
   storage_encrypted       = "${data.aws_db_instance.source_database.storage_encrypted}"
-  storage_type            = "${data.aws_db_instance.source_database.storage_type}"
+  storage_type            = "${var.storage_type != "" ? var.storage_type : data.aws_db_instance.source_database.storage_type}"
 }
 
 resource "aws_db_instance" "mod" {

--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -29,6 +29,7 @@ resource "aws_db_instance" "mod" {
   final_snapshot_identifier   = "${var.name}-${var.env}-${local.engine}-final-snapshot"
   identifier                  = "${var.identifier != "" ? var.identifier : "${var.name}-${var.env}-${local.engine}"}"
   instance_class              = "${var.node_type}"
+  iops                        = "${var.iops}"
   multi_az                    = "${var.multi_az}"
   option_group_name           = "${"default:${local.engine}-${replace(local.major_engine_version, ".", "-")}"}"
   parameter_group_name        = "${local.parameter_group_name}"

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -71,6 +71,11 @@ variable "source_db" {
   description = "Source database identifier."
 }
 
+variable "storage_type" {
+  description = "(Optional) One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is the storage type of the source database, so only set this if you want to use a different storage type on the replica."
+  default     = ""
+}
+
 variable "vpc_id" {
   description = "VPC id to associate this RDS instance with."
 }

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -23,6 +23,11 @@ variable "identifier" {
   default     = ""
 }
 
+variable "iops" {
+  description = "(Optional) The amount of provisioned IOPS. Setting this implies a storage_type of io1."
+  default     = 0
+}
+
 variable "multi_az" {
   description = "AWS RDS automatically creates a primary DB Instance and synchronously replicates the data to a standby instance in a different Availability Zone."
   default     = false

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -37,6 +37,7 @@ resource "aws_db_instance" "mod" {
   engine_version              = "${var.engine_version}"
   final_snapshot_identifier   = "${var.name}-${var.env}-${var.engine}-final-snapshot"
   identifier                  = "${var.identifier != "" ? var.identifier : "${var.name}-${var.env}-${var.engine}"}"
+  iops                        = "${var.iops}"
   instance_class              = "${var.node_type}"
   kms_key_id                  = "${var.kms_key_id}"
   multi_az                    = "${var.multi_az}"

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -35,6 +35,11 @@ variable "identifier" {
   default     = ""
 }
 
+variable "iops" {
+  description = "(Optional) The amount of provisioned IOPS. Setting this implies a storage_type of io1."
+  default     = 0
+}
+
 variable "kms_key_id" {
   description = "If you are using volume encryption, you can use this variable to set the specific key arn."
   default     = ""

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -100,7 +100,7 @@ variable "storage_encrypted" {
 }
 
 variable "storage_type" {
-  description = "Volume type to use.  Options: Standard(magnetic), gp2(SSD)"
+  description = "(Optional) One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'."
   default     = "gp2"
 }
 


### PR DESCRIPTION
D1’s production replica needs Provisioned IOPS to be able to keep up with the primary (as we learned the hard way).

This PR adds support for doing so both to aws/database_replica (which we use and a PR is forthcoming for), and aws/rds (for parity). @danhodos and I got around the problem in https://github.com/tablexi/terraform_modules/pull/115 by using `iops = 0` to mean “no IOPS, thanks”, rather than `iops =''`.