### PR TITLE
Stop specifying option_group_name in //aws/database_replica

### DIFF
--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -31,7 +31,6 @@ resource "aws_db_instance" "mod" {
   instance_class              = "${var.node_type}"
   iops                        = "${var.iops}"
   multi_az                    = "${var.multi_az}"
-  option_group_name           = "${"default:${local.engine}-${replace(local.major_engine_version, ".", "-")}"}"
   parameter_group_name        = "${local.parameter_group_name}"
   publicly_accessible         = "${var.publicly_accessible}"
   replicate_source_db         = "${local.source_db}"


### PR DESCRIPTION
We no longer specify `option_group_name` for `//aws/rds`, so we should stop doing so here.

Specifically, when I tried to use this module today to create a replica with a different `engine_version` from its primary, I got this error message:

```
* aws_db_instance.mod: Error creating DB Instance: InvalidParameterCombination: The option group default:mysql-5-7 is for mysql 5.7, and your DB instance is mysql 5.5.
	status code: 400, request id: c4006c57-806f-439f-aace-2810b24b59f2
```

This happens because a replica always gets created from the most recent snapshot of its primary, which puts it at the same version, and it then gets upgraded in place. As a result, if we compute `option_group_name` (which we don’t need to), we’d be assigning a default option group name before the replica exists, and AWS gives us an error.