### PR TITLE
Do not require subnets when a subnet_group_name is specified in aws/rds

### DIFF
--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -105,12 +105,12 @@ variable "storage_type" {
 }
 
 variable "subnets" {
-  description = "A list of subnets that the RDS instance can be added to."
-  type        = "list"
+  description = "A list of subnets that the RDS instance can be added to. Either subnets or subnet_group_name must be specified."
+  default     = []
 }
 
 variable "subnet_group_name" {
-  description = "Set db subnet group name"
+  description = "Set db subnet group name. Either subnets or subnet_group_name must be specified."
   default     = ""
 }
 


### PR DESCRIPTION
In `aws/rds`, we allow specifying `subnet_group_name`, so that no DB subnet group is created by the module. In this case, we should not be requiring `subnets`, because that argument is unused, and that’s what this PR does.