### PR TITLE
Add node_security_group_id output to aws/eks

### DIFF
--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -6,6 +6,10 @@ output "node_instance_role" {
   value = "${aws_cloudformation_stack.nodes.outputs["NodeInstanceRole"]}"
 }
 
+output "node_security_group_id" {
+  value = "${aws_cloudformation_stack.nodes.outputs["NodeSecurityGroup"]}"
+}
+
 output "subnets" {
   value = "${module.eks-subnets.subnets}"
 }


### PR DESCRIPTION
This came in handy for @danhodos and I to be able to write an `aws_security_group_rule` to allow ingress on port 22, and ssh onto the EKS nodes!