### PR TITLE
Forward only to a single target group in application_load_balancer

### DIFF
--- a/aws/application_load_balancer/main.tf
+++ b/aws/application_load_balancer/main.tf
@@ -53,7 +53,7 @@ resource "aws_alb_listener" "http_listener" {
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_alb_target_group.http_target_group.arn}"
+    target_group_arn = "${aws_alb_target_group.target_group.arn}"
     type             = "forward"
   }
 }
@@ -101,39 +101,6 @@ resource "aws_alb_listener_rule" "redirect_http_to_https" {
   }
 }
 
-resource "aws_alb_target_group" "http_target_group" {
-  deregistration_delay = 30
-  name                 = "${local.prefix}-http"
-  port                 = "${var.http_target_group_port}"
-  protocol             = "HTTP"
-  vpc_id               = "${var.vpc_id}"
-
-  health_check {
-    matcher  = "${var.http_health_check_matcher}"
-    path     = "${var.health_check_path}"
-    port     = "${var.http_target_group_port}"
-    protocol = "HTTP"
-    timeout  = 5
-  }
-
-  tags = "${var.tags}"
-}
-
-resource "aws_alb_target_group_attachment" "http_target_group_attachments" {
-  count            = "${var.instances_count}"
-  target_group_arn = "${aws_alb_target_group.http_target_group.arn}"
-  target_id        = "${element(var.instances, count.index)}"
-}
-
-resource "aws_security_group_rule" "http_ingress_on_instances_from_load_balancer" {
-  from_port                = "${var.http_target_group_port}"
-  protocol                 = "tcp"
-  security_group_id        = "${var.security_group_for_instances}"
-  source_security_group_id = "${aws_security_group.security_group_on_load_balancer.id}"
-  to_port                  = "${var.http_target_group_port}"
-  type                     = "ingress"
-}
-
 resource "aws_alb_listener" "https_listener" {
   certificate_arn   = "${var.certificate_arn}"
   load_balancer_arn = "${module.load_balancer.arn}"
@@ -142,7 +109,7 @@ resource "aws_alb_listener" "https_listener" {
   ssl_policy        = "${var.ssl_policy}"
 
   default_action {
-    target_group_arn = "${aws_alb_target_group.http_target_group.arn}"
+    target_group_arn = "${aws_alb_target_group.target_group.arn}"
     type             = "forward"
   }
 }
@@ -167,37 +134,35 @@ resource "aws_alb_listener_rule" "redirect_domains_https" {
   }
 }
 
-resource "aws_alb_target_group" "https_target_group" {
-  count                = "${var.https_target_group ? 1 : 0}"
+resource "aws_alb_target_group" "target_group" {
   deregistration_delay = 30
-  name                 = "${local.prefix}-https"
-  port                 = "${var.https_target_group_port}"
-  protocol             = "HTTPS"
+  name                 = "${local.prefix}"
+  port                 = "${var.target_group_port}"
+  protocol             = "${var.target_group_protocol}"
   vpc_id               = "${var.vpc_id}"
 
   health_check {
-    matcher  = "${var.https_health_check_matcher}"
+    matcher  = "${var.health_check_matcher}"
     path     = "${var.health_check_path}"
-    port     = "${var.https_target_group_port}"
-    protocol = "HTTPS"
+    port     = "${var.target_group_port}"
+    protocol = "HTTP"
     timeout  = 5
   }
 
   tags = "${var.tags}"
 }
 
-resource "aws_alb_target_group_attachment" "https_target_group_attachments" {
-  count            = "${var.https_target_group ? var.instances_count : 0}"
-  target_group_arn = "${aws_alb_target_group.https_target_group.arn}"
+resource "aws_alb_target_group_attachment" "target_group_attachments" {
+  count            = "${var.instances_count}"
+  target_group_arn = "${aws_alb_target_group.target_group.arn}"
   target_id        = "${element(var.instances, count.index)}"
 }
 
-resource "aws_security_group_rule" "https_ingress_on_instances_from_load_balancer" {
-  count                    = "${var.https_target_group ? 1 : 0}"
-  from_port                = "${var.https_target_group_port}"
+resource "aws_security_group_rule" "ingress_on_instances_from_load_balancer" {
+  from_port                = "${var.target_group_port}"
   protocol                 = "tcp"
   security_group_id        = "${var.security_group_for_instances}"
   source_security_group_id = "${aws_security_group.security_group_on_load_balancer.id}"
-  to_port                  = "${var.https_target_group_port}"
+  to_port                  = "${var.target_group_port}"
   type                     = "ingress"
 }

--- a/aws/application_load_balancer/main.tf
+++ b/aws/application_load_balancer/main.tf
@@ -145,7 +145,7 @@ resource "aws_alb_target_group" "target_group" {
     matcher  = "${var.health_check_matcher}"
     path     = "${var.health_check_path}"
     port     = "${var.target_group_port}"
-    protocol = "HTTP"
+    protocol = "${var.target_group_protocol}"
     timeout  = 5
   }
 

--- a/aws/application_load_balancer/outputs.tf
+++ b/aws/application_load_balancer/outputs.tf
@@ -3,7 +3,7 @@ output "dns_name" {
 }
 
 output "target_group_arns" {
-  value = ["${compact(concat(aws_alb_target_group.https_target_group.*.arn, aws_alb_target_group.http_target_group.*.arn))}"]
+  value = ["${aws_alb_target_group.target_group.*.arn}"]
 }
 
 output "zone_id" {

--- a/aws/application_load_balancer/variables.tf
+++ b/aws/application_load_balancer/variables.tf
@@ -48,29 +48,9 @@ variable "health_check_path" {
   default     = "/healthz"
 }
 
-variable "http_health_check_matcher" {
+variable "health_check_matcher" {
   description = "(Optional) Health check matcher for the HTTP target group. Default '200,301'."
   default     = "200,301"
-}
-
-variable "http_target_group_port" {
-  description = "(Optional) Port for the targets in the HTTP target group. Default '80'."
-  default     = "80"
-}
-
-variable "https_health_check_matcher" {
-  description = "(Optional) Health check matcher for the HTTPS target group. Default '200'."
-  default     = "200,301"
-}
-
-variable "https_target_group" {
-  description = "(Optional) If true, the HTTPS listener will forward to a HTTPS target group. If false, the HTTPS listener will forward to a HTTP target group. Default true."
-  default     = true
-}
-
-variable "https_target_group_port" {
-  description = "(Optional) Port for the targets in the HTTPS target group. Default '443'."
-  default     = "443"
 }
 
 variable "ingress_cidr_blocks" {
@@ -112,4 +92,14 @@ variable "tags" {
   default     = {}
   description = "(Optional) A mapping of tags to assign to the resources"
   type        = "map"
+}
+
+variable "target_group_port" {
+  description = "(Optional) Port for the targets in the HTTP target group. Default '80'."
+  default     = "80"
+}
+
+variable "target_group_protocol" {
+  description = "(Optional) Protocol for the targets in the HTTP target group. Default 'HTTP'."
+  default     = "HTTP"
 }


### PR DESCRIPTION
Cleans up the module `application_load_balancer` so that there is only one target group that its listeners forward traffic to, and it makes it possible to specify the port and protocol for that target group. They default to 80 and HTTP, but by allowing these values to be overridden, we can support backends like Chef server, which embed their own nginx and must be routed to on port 443 on the instances.