### PR TITLE
Do not add cluster name twice to EKS node names

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -104,7 +104,7 @@ resource "aws_cloudformation_stack" "nodes" {
     NodeAutoScalingGroupDesiredCapacity = "${var.capacity_desired}"
     NodeAutoScalingGroupMaxSize         = "${var.capacity_max}"
     NodeAutoScalingGroupMinSize         = "${var.capacity_min}"
-    NodeGroupName                       = "${var.name}"
+    NodeGroupName                       = "default"
     NodeImageId                         = "${var.ami}"
     NodeInstanceType                    = "${var.instance_type}"
     Subnets                             = "${join(",", module.eks-subnets.subnets)}"


### PR DESCRIPTION
The CloudFormation template we use constructs the EC2 nodes’ names like so:

```
        - Key: Name
          Value: !Sub ${ClusterName}-${NodeGroupName}-Node
          PropagateAtLaunch: true
```

As a result, if we specify `ClusterName` and `NodeGroupName` to the same value, like we currently do, we get EC2 instance names like `eks-development-eks-development-Node`. With this change, since we’re only creating one node group, we now call it `default`, and the EC2 instances will be named `eks-development-default-Node`