### PR TITLE
Fix JSON property name in aws/cloudtrail

### DIFF
--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket" "mod" {
           Action = "s3:PutObject"
           Condition = {
             StringEquals = {
-              s3:x-amz-acl = "bucket-owner-full-control"
+              "s3:x-amz-acl" = "bucket-owner-full-control"
             }
           }
           Effect = "Allow"


### PR DESCRIPTION
`s3:x-amz-acl` is not a valid property name literal, so it needs to be enclosed in quotes to be usable. Otherwise, Terraform 0.12 fails with an error.