### PR TITLE
Create replacement target groups before destroying existing ones

### DIFF
--- a/aws/application_load_balancer/main.tf
+++ b/aws/application_load_balancer/main.tf
@@ -150,12 +150,20 @@ resource "aws_alb_target_group" "target_group" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_alb_target_group_attachment" "target_group_attachments" {
   count            = length(var.instances)
   target_group_arn = aws_alb_target_group.target_group.arn
   target_id        = element(var.instances, count.index)
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "ingress_on_instances_from_load_balancer" {
@@ -165,5 +173,9 @@ resource "aws_security_group_rule" "ingress_on_instances_from_load_balancer" {
   source_security_group_id = aws_security_group.security_group_on_load_balancer.id
   to_port                  = var.target_group_port
   type                     = "ingress"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 


### PR DESCRIPTION
This way, if anything about the name changes, the new target group to which the listeners will route will be created first, the listeners will be updated, and the old target group will then be destroyed without any service disruptions.

The current code results in a Terraform error when it first tries to delete the target group, since it is being used by listener rules.