### PR TITLE
Fix TF-UPGRADE-TODO in aws/database_replica

### DIFF
--- a/aws/database_replica/main.tf
+++ b/aws/database_replica/main.tf
@@ -45,18 +45,11 @@ resource "aws_db_instance" "mod" {
   skip_final_snapshot         = var.skip_final_snapshot
   storage_encrypted           = local.storage_encrypted
   storage_type                = local.storage_type
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibilty in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
-  vpc_security_group_ids = [concat(
+
+  vpc_security_group_ids = concat(
     var.vpc_security_group_ids,
     [aws_security_group.sg_on_rds_instance.id],
-  )]
+  )
 
   tags = var.tags
 }


### PR DESCRIPTION
Fixes the issue identified by a `TF-UPGRADE-TODO` in `aws/database_replica` — without this, Terraform complains about a mismatch in types due to the pre-0.12 hack that is no longer necessary here.