### PR TITLE
Stop creating empty parameter groups for Elasticache and use default

### DIFF
--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -7,11 +7,6 @@ variable "automatic_failover_enabled" {
   description = "(Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If true, Multi-AZ is enabled for this replication group. If false, Multi-AZ is disabled for this replication group. Must be enabled for Redis (cluster mode enabled) replication groups. Defaults to false."
 }
 
-variable "create_parameter_group" {
-  default     = true
-  description = "Create a parameter group in this module"
-}
-
 variable "engine" {
   description = "redis, memcache, etc."
 }
@@ -41,11 +36,6 @@ variable "node_type" {
 
 variable "num_nodes" {
   default = 1
-}
-
-variable "parameter_group_name" {
-  description = "Name of a parameter group to use with the Elasticache instance."
-  default     = ""
 }
 
 variable "port" {


### PR DESCRIPTION
Changes our Elasticache code to use the default parameter groups instead of creating empty clones of them, which are troublesome to migrate (since changing a name requires that they be destroyed and recreted) and unnecessary.