### PR TITLE
Support blacklisted_names in //aws/vpc/subnets

### DIFF
--- a/aws/vpc/subnets/main.tf
+++ b/aws/vpc/subnets/main.tf
@@ -1,5 +1,6 @@
 # Find the available availability zones
 data "aws_availability_zones" "available" {
+  blacklisted_names = var.blacklisted_names
 }
 
 data "aws_vpc" "current" {

--- a/aws/vpc/subnets/main.tf
+++ b/aws/vpc/subnets/main.tf
@@ -7,30 +7,6 @@ data "aws_vpc" "current" {
   id = var.vpc_id
 }
 
-locals {
-  default_az_to_netnum = {
-    a = 1
-    b = 2
-    c = 3
-    d = 4
-    e = 5
-    f = 6
-  }
-}
-
-data "template_file" "az_to_netnum" {
-  count    = length(data.aws_availability_zones.available.names)
-  template = "$${netnum}"
-
-  vars = {
-    netnum = local.default_az_to_netnum[substr(
-      element(data.aws_availability_zones.available.names, count.index),
-      -1,
-      1,
-    )]
-  }
-}
-
 resource "aws_route_table" "mod" {
   tags   = var.tags
   vpc_id = var.vpc_id
@@ -49,7 +25,7 @@ resource "aws_subnet" "mod" {
   cidr_block = cidrsubnet(
     data.aws_vpc.current.cidr_block,
     var.newbits,
-    var.netnum_offset + element(data.template_file.az_to_netnum[*].rendered, count.index),
+    var.netnum_offset + count.index + 1,
   )
   map_public_ip_on_launch = var.public
   tags                    = var.tags

--- a/aws/vpc/subnets/variables.tf
+++ b/aws/vpc/subnets/variables.tf
@@ -21,6 +21,11 @@ variable "netnum_offset" {
   description = "Offset the subnets netnum by a specific amount."
 }
 
+variable "blacklisted_names" {
+  default     = []
+  description = "(Optional) List of blacklisted Availability Zone names."
+}
+
 variable "tags" {
   description = "(Optional) A mapping of tags to assign to the resources"
   type        = map(string)


### PR DESCRIPTION
In some cases, we’ve skipped a subnet for historical reasons, and we have subnets like `us-east-1a`, `us-east-1c`, `us-east-1d`, and so on.

This PR allows migrating these historical use cases to the //aws/vpc/subnets module without having to rebuild the subnets, through the support of `blacklisted_names` as a variable. By specifying it, one can skip over an availability zone. In addition to this, removing the manual, hard-coded mapping of letters to numbers, and replacing it with a count-based index only, allows us to maintain the existing AZ-to-subnet-CIDR-block mapping, enabling us to use the module without rebuilding everything in the VPC.