### PR TITLE
Revert "Stop creating empty parameter groups for Elasticache and use default"

### DIFF
--- a/aws/elasticache/main.tf
+++ b/aws/elasticache/main.tf
@@ -5,6 +5,7 @@ locals {
 locals {
   cluster_name                  = "${var.name}-${var.env}"
   family                        = "${var.engine}${local.version_major_minor_only}"
+  parameter_group_name          = var.parameter_group_name != "" ? var.parameter_group_name : "${local.cluster_name}-params${replace(local.version_major_minor_only, ".", "")}"
   port                          = var.port != "" ? var.port : var.engine == "redis" ? "6379" : "11211"
   elasticache_replication_group = var.force_replication_group || var.num_nodes != 1
   cluster_tags = merge(
@@ -26,6 +27,7 @@ resource "aws_elasticache_cluster" "mod" {
   maintenance_window   = var.maintenance_window
   node_type            = var.node_type
   port                 = local.port
+  parameter_group_name = local.parameter_group_name
   security_group_ids   = [aws_security_group.sg_on_elasticache_instance.id]
   subnet_group_name    = aws_elasticache_subnet_group.mod.name
 
@@ -42,6 +44,7 @@ resource "aws_elasticache_replication_group" "mod" {
   maintenance_window            = var.maintenance_window
   node_type                     = var.node_type
   number_cache_clusters         = var.num_nodes
+  parameter_group_name          = aws_elasticache_parameter_group.mod[0].id
   port                          = local.port
   replication_group_description = "${var.name} ${var.env} ${var.engine} instance"
   replication_group_id          = local.cluster_name
@@ -50,6 +53,17 @@ resource "aws_elasticache_replication_group" "mod" {
   transit_encryption_enabled    = var.transit_encryption_enabled
 
   tags = local.cluster_tags
+}
+
+resource "aws_elasticache_parameter_group" "mod" {
+  count       = var.create_parameter_group ? 1 : 0
+  name        = local.parameter_group_name
+  family      = local.family
+  description = "${var.name} ${var.env} env ${var.engine} cluster param group"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_elasticache_subnet_group" "mod" {

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -7,6 +7,11 @@ variable "automatic_failover_enabled" {
   description = "(Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If true, Multi-AZ is enabled for this replication group. If false, Multi-AZ is disabled for this replication group. Must be enabled for Redis (cluster mode enabled) replication groups. Defaults to false."
 }
 
+variable "create_parameter_group" {
+  default     = true
+  description = "Create a parameter group in this module"
+}
+
 variable "engine" {
   description = "redis, memcache, etc."
 }
@@ -36,6 +41,11 @@ variable "node_type" {
 
 variable "num_nodes" {
   default = 1
+}
+
+variable "parameter_group_name" {
+  description = "Name of a parameter group to use with the Elasticache instance."
+  default     = ""
 }
 
 variable "port" {


### PR DESCRIPTION
Reverts tablexi/terraform_modules#140 temporarily, so I can finish some Terraform 0.12 upgrades in the meantime, without having to change their Elasticache setups.