### PR TITLE
Use aws_eks_node_group to manage EKS nodes

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -103,26 +103,69 @@ resource "aws_eks_cluster" "master" {
   ]
 }
 
-resource "aws_cloudformation_stack" "nodes" {
-  capabilities = ["CAPABILITY_IAM"]
-  depends_on   = [aws_eks_cluster.master]
-  name         = var.name
-  tags         = local.tags
-  template_url = "https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2019-02-11/amazon-eks-nodegroup.yaml"
+data "aws_iam_policy_document" "nodes_assume_role_policy" {
+  version = "2012-10-17"
 
-  parameters = {
-    ClusterControlPlaneSecurityGroup    = aws_security_group.master.id
-    ClusterName                         = var.name
-    KeyName                             = var.key_name
-    NodeAutoScalingGroupDesiredCapacity = var.capacity_desired
-    NodeAutoScalingGroupMaxSize         = var.capacity_max
-    NodeAutoScalingGroupMinSize         = var.capacity_min
-    NodeGroupName                       = "default"
-    NodeImageId                         = var.ami
-    NodeInstanceType                    = var.instance_type
-    Subnets                             = join(",", module.eks-subnets.subnets)
-    VpcId                               = module.eks-vpc.vpc_id
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
   }
+}
+
+resource "aws_iam_role" "nodes" {
+  name               = "${var.name}-nodes"
+  assume_role_policy = data.aws_iam_policy_document.nodes_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "nodes-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "nodes-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "nodes-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_eks_node_group" "default" {
+  cluster_name    = var.name
+  instance_types  = [var.instance_type]
+  node_group_name = "default"
+  node_role_arn   = aws_iam_role.nodes.arn
+
+  scaling_config {
+    desired_size = var.capacity_desired
+    max_size     = var.capacity_max
+    min_size     = var.capacity_min
+  }
+
+  subnet_ids = [
+    "${lookup(module.eks-subnets.subnets_by_az, "us-east-1b")}",
+    "${lookup(module.eks-subnets.subnets_by_az, "us-east-1c")}",
+    "${lookup(module.eks-subnets.subnets_by_az, "us-east-1d")}",
+    "${lookup(module.eks-subnets.subnets_by_az, "us-east-1e")}",
+    "${lookup(module.eks-subnets.subnets_by_az, "us-east-1f")}",
+  ]
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_eks_cluster.master,
+    aws_iam_role_policy_attachment.nodes-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.nodes-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.nodes-AmazonEC2ContainerRegistryReadOnly,
+  ]
 }
 
 resource "aws_cloudwatch_log_group" "logs" {
@@ -172,9 +215,5 @@ resource "aws_iam_policy" "cluster-logging" {
 
 resource "aws_iam_role_policy_attachment" "cluster-logging" {
   policy_arn = aws_iam_policy.cluster-logging.arn
-  role = replace(
-    aws_cloudformation_stack.nodes.outputs["NodeInstanceRole"],
-    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/",
-    "",
-  )
+  role = aws_iam_role.nodes.name
 }

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -3,11 +3,7 @@ output "master_security_group_id" {
 }
 
 output "node_instance_role" {
-  value = aws_cloudformation_stack.nodes.outputs["NodeInstanceRole"]
-}
-
-output "node_security_group_id" {
-  value = aws_cloudformation_stack.nodes.outputs["NodeSecurityGroup"]
+  value = aws_iam_role.nodes.arn
 }
 
 output "subnets" {

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -7,11 +7,6 @@ variable "tags" {
   type        = map(string)
 }
 
-variable "ami" {
-  description = "AMI used to build each node"
-  default     = "ami-0d9f458329e942f90"
-}
-
 variable "instance_type" {
   default = "t3.medium"
 }
@@ -30,7 +25,3 @@ variable "capacity_max" {
   description = "Maximum number of nodes to create"
   default     = 6
 }
-
-variable "key_name" {
-}
-


### PR DESCRIPTION
Applies the same code we have over at https://github.com/tablexi/terraform_modules/tree/tf11-use-eks-managed-node-groups, to `master`, so that it is usable with Terraform 0.12