### PR TITLE
Add private_ips as output in aws/ec2

### DIFF
--- a/aws/ec2/outputs.tf
+++ b/aws/ec2/outputs.tf
@@ -6,6 +6,10 @@ output "public_ips" {
   value = var.enable_eip ? aws_eip.mod[*].public_ip : aws_instance.mod[*].public_ip
 }
 
+output "private_ips" {
+  value = var.enable_eip ? aws_eip.mod[*].private_ip : aws_instance.mod[*].private_ip
+}
+
 output "security_group_on_instances" {
   value = aws_security_group.security_group_on_instances.id
 }


### PR DESCRIPTION
Needed by Dickson’s staging export server, this PR adds `private_ips` as an output of `//aws/ec2`.