### PR TITLE
Enable Enhanced Monitoring for RDS, with a default interval of 60 seconds

### DIFF
--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -50,6 +50,7 @@ resource "aws_db_instance" "mod" {
   iops                        = var.iops
   instance_class              = var.node_type
   kms_key_id                  = var.kms_key_id
+  monitoring_interval         = var.monitoring_interval
   multi_az                    = var.multi_az
   parameter_group_name        = local.parameter_group_name
   password                    = "nopassword"

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -20,12 +20,10 @@ variable "env" {
 
 variable "engine" {
   description = "Postgres, MySQL, etc."
-  # default = "postgres"
 }
 
 variable "engine_version" {
   description = "Version # of the Postgres or MySQL installation. Do not include patch version as it is auto upgraded."
-  # default = "9.6"
 }
 
 variable "identifier" {
@@ -41,6 +39,11 @@ variable "iops" {
 variable "kms_key_id" {
   description = "If you are using volume encryption, you can use this variable to set the specific key arn."
   default     = ""
+}
+
+variable "monitoring_interval" {
+  default     = 60
+  description = "(Optional) The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 60. Valid Values: 0, 1, 5, 10, 15, 30, 60."
 }
 
 variable "multi_az" {


### PR DESCRIPTION
Part of https://github.com/tablexi/terraform_modules/issues/148, this PR makes our RDS module enable enhanced monitoring, with a default monitoring interval of 60 seconds.