### PR TITLE
Create module for redirects

### DIFF
--- a/aws/application_load_balancer/main.tf
+++ b/aws/application_load_balancer/main.tf
@@ -84,7 +84,7 @@ resource "aws_alb_listener_rule" "redirect_domains_http" {
 resource "aws_alb_listener_rule" "redirect_http_to_https" {
   count        = var.redirect_http_to_https ? 1 : 0
   listener_arn = aws_alb_listener.http_listener.arn
-  priority     = 1000
+  priority     = 50000
 
   action {
     type = "redirect"

--- a/aws/redirects/main.tf
+++ b/aws/redirects/main.tf
@@ -1,0 +1,43 @@
+resource "aws_lb_listener_rule" "http_redirects" {
+  for_each     = var.rules
+  listener_arn = var.load_balancer.http_listener_arn
+
+  condition {
+    host_header {
+      values = [each.key]
+    }
+  }
+
+  action {
+    type = "redirect"
+    redirect {
+      host        = each.value["host"]
+      path        = each.value["path"]
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "https_redirects" {
+  for_each     = var.rules
+  listener_arn = var.load_balancer.https_listener_arn
+
+  condition {
+    host_header {
+      values = [each.key]
+    }
+  }
+
+  action {
+    type = "redirect"
+    redirect {
+      host        = each.value["host"]
+      path        = each.value["path"]
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}

--- a/aws/redirects/main.tf
+++ b/aws/redirects/main.tf
@@ -1,3 +1,7 @@
+locals {
+  starting_priority = 1000
+}
+
 resource "aws_route53_record" "aliases" {
   for_each = var.rules
 
@@ -16,6 +20,7 @@ resource "aws_lb_listener_rule" "http_redirects" {
   for_each = var.rules
 
   listener_arn = var.load_balancer.http_listener_arn
+  priority     = local.starting_priority + index(keys(var.rules), each.key)
 
   condition {
     host_header {
@@ -39,6 +44,7 @@ resource "aws_lb_listener_rule" "https_redirects" {
   for_each = var.rules
 
   listener_arn = var.load_balancer.https_listener_arn
+  priority     = local.starting_priority + index(keys(var.rules), each.key)
 
   condition {
     host_header {

--- a/aws/redirects/main.tf
+++ b/aws/redirects/main.tf
@@ -32,7 +32,7 @@ resource "aws_lb_listener_rule" "http_redirects" {
     type = "redirect"
     redirect {
       host        = each.value["host"]
-      path        = each.value["path"]
+      path        = lookup(each.value, "path", "/#{path}")
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_301"
@@ -56,7 +56,7 @@ resource "aws_lb_listener_rule" "https_redirects" {
     type = "redirect"
     redirect {
       host        = each.value["host"]
-      path        = each.value["path"]
+      path        = lookup(each.value, "path", "/#{path}")
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_301"

--- a/aws/redirects/main.tf
+++ b/aws/redirects/main.tf
@@ -1,3 +1,13 @@
+resource "aws_route53_record" "cnames" {
+  for_each = var.rules
+
+  name    = each.key
+  records = [var.load_balancer.dns_name]
+  ttl     = 60
+  type    = "CNAME"
+  zone_id = var.dns_zone.id
+}
+
 resource "aws_lb_listener_rule" "http_redirects" {
   for_each     = var.rules
   listener_arn = var.load_balancer.http_listener_arn

--- a/aws/redirects/variables.tf
+++ b/aws/redirects/variables.tf
@@ -1,0 +1,8 @@
+variable "load_balancer" {
+}
+
+variable "dns_zone" {
+}
+
+variable "rules" {
+}

--- a/aws/redirects/variables.tf
+++ b/aws/redirects/variables.tf
@@ -1,8 +1,11 @@
 variable "load_balancer" {
+  description = "application_load_balancer module to attach rules to"
 }
 
 variable "dns_zone" {
+  description = "aws_route53_zone to create DNS alias records in"
 }
 
 variable "rules" {
+  description = "Map of redirects to create, with key as hostname and value as map of host and path"
 }


### PR DESCRIPTION
This is intended to replace the `redirect_domains` variable on `application_load_balancer` with a mechanism that allows for arbitrary redirects when the path is different. Swanky.