### PR TITLE
Fix interpolation-only expressions in aws/rds

### DIFF
--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -102,7 +102,7 @@ resource "aws_security_group" "sg_on_rds_instance" {
 }
 
 resource "aws_iam_role" "rds_enhanced_monitoring" {
-  assume_role_policy = "${data.aws_iam_policy_document.rds_enhanced_monitoring[0].json}"
+  assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring[0].json
   count              = var.monitoring_interval == 0 ? 0 : 1
   name_prefix        = "rds-enhanced-monitoring"
 }
@@ -110,7 +110,7 @@ resource "aws_iam_role" "rds_enhanced_monitoring" {
 resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
   count      = var.monitoring_interval == 0 ? 0 : 1
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
-  role       = "${aws_iam_role.rds_enhanced_monitoring[0].name}"
+  role       = aws_iam_role.rds_enhanced_monitoring[0].name
 }
 
 data "aws_iam_policy_document" "rds_enhanced_monitoring" {


### PR DESCRIPTION
Fixes these Terraform warnings:

```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/something/aws/rds/main.tf line 105, in resource "aws_iam_role" "rds_enhanced_monitoring":
 105:   assume_role_policy = "${data.aws_iam_policy_document.rds_enhanced_monitoring[0].json}"
```