### PR TITLE
Remove unused variables from aws/ec2 module

### DIFF
--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -77,8 +77,7 @@ resource "aws_security_group_rule" "all_ingress_on_instances_from_self" {
 }
 
 resource "aws_security_group_rule" "ssh_ingress_on_instances_cidr_blocks" {
-  count             = length(var.ssh_ingress_cidr_blocks) > 0 ? 1 : 0
-  cidr_blocks       = var.ssh_ingress_cidr_blocks
+  cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
   protocol          = "tcp"
   security_group_id = aws_security_group.security_group_on_instances.id

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -84,14 +84,3 @@ resource "aws_security_group_rule" "ssh_ingress_on_instances_cidr_blocks" {
   to_port           = 22
   type              = "ingress"
 }
-
-resource "aws_security_group_rule" "ssh_ingress_on_instances_sgs" {
-  count                    = length(var.ssh_ingress_sgs)
-  source_security_group_id = element(var.ssh_ingress_sgs, count.index)
-  from_port                = 22
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.security_group_on_instances.id
-  to_port                  = 22
-  type                     = "ingress"
-}
-

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -16,8 +16,6 @@ resource "aws_instance" "mod" {
   associate_public_ip_address = var.associate_public_ip_address
   iam_instance_profile        = var.iam_instance_profile
 
-  source_dest_check = var.source_dest_check
-
   tags = merge(
     {
       "Name" = format(

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -33,9 +33,9 @@ resource "aws_instance" "mod" {
   ebs_optimized = var.ebs_optimized
 
   root_block_device {
-    volume_type           = var.root_block_type
+    delete_on_termination = false
     volume_size           = var.root_block_size
-    delete_on_termination = var.root_block_termination
+    volume_type           = var.root_block_type
   }
 
   lifecycle {

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -13,7 +13,7 @@ resource "aws_instance" "mod" {
   key_name                    = var.key_name
   vpc_security_group_ids      = concat(list(aws_security_group.security_group_on_instances.id), var.vpc_security_group_ids)
   subnet_id                   = element(var.subnets, count.index)
-  associate_public_ip_address = var.associate_public_ip_address
+  associate_public_ip_address = true
   iam_instance_profile        = var.iam_instance_profile
 
   tags = merge(

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -1,7 +1,3 @@
-variable "associate_public_ip_address" {
-  default = true
-}
-
 variable "ami" {
   description = "(Required) The AMI to use for the instance."
 }

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -79,9 +79,3 @@ variable "iam_instance_profile" {
   default     = ""
   description = "The IAM instance profile to associate with the instance."
 }
-
-variable "source_dest_check" {
-  default     = true
-  description = "Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs."
-}
-

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -36,10 +36,6 @@ variable "root_block_size" {
   default = 16
 }
 
-variable "ssh_ingress_sgs" {
-  default = []
-}
-
 variable "subnets" {
   type = list(string)
 }

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -40,10 +40,6 @@ variable "root_block_size" {
   default = 16
 }
 
-variable "ssh_ingress_cidr_blocks" {
-  default = ["0.0.0.0/0"]
-}
-
 variable "ssh_ingress_sgs" {
   default = []
 }

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -40,10 +40,6 @@ variable "root_block_size" {
   default = 16
 }
 
-variable "root_block_termination" {
-  default = false
-}
-
 variable "ssh_ingress_cidr_blocks" {
   default = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
This PR eliminates a few never-overridden variables from the aws/ec2 module — some of them I just inlined in the places where we were using them (if we were using a value different from Terraform’s default), whereas others I completely removed (where we were using the value that is Terraform’s default).