### PR TITLE
Enable remote access to EKS node groups

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -1,9 +1,5 @@
 locals {
-  default_tags = {
-    Name = var.name
-  }
-
-  tags = merge(local.default_tags, var.tags)
+  tags = merge({ Name = var.name }, var.tags)
 }
 
 module "eks-vpc" {

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -138,6 +138,10 @@ resource "aws_eks_node_group" "default" {
   node_group_name = "default"
   node_role_arn   = aws_iam_role.nodes.arn
 
+  remote_access {
+    ec2_ssh_key = var.ec2_ssh_key
+  }
+
   scaling_config {
     desired_size = var.capacity_desired
     max_size     = var.capacity_max

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -1,16 +1,3 @@
-variable "name" {
-  description = "Name of the cluster"
-}
-
-variable "tags" {
-  description = "(Optional) A mapping of tags to assign to the resources"
-  type        = map(string)
-}
-
-variable "instance_type" {
-  default = "t3.medium"
-}
-
 variable "capacity_min" {
   description = "Minimum number of nodes to create"
   default     = 3
@@ -24,4 +11,22 @@ variable "capacity_desired" {
 variable "capacity_max" {
   description = "Maximum number of nodes to create"
   default     = 6
+}
+
+variable "ec2_ssh_key" {
+  description = "(Optional) EC2 Key Pair name that provides access for SSH communication with the worker nodes in the EKS Node Group."
+  type        = string
+}
+
+variable "instance_type" {
+  default = "t3.medium"
+}
+
+variable "name" {
+  description = "Name of the cluster"
+}
+
+variable "tags" {
+  description = "(Optional) A mapping of tags to assign to the resources"
+  type        = map(string)
 }


### PR DESCRIPTION
For now, we require `ec2_ssh_key` so we don’t end up in another situation where a node is misbehaving, and we can’t SSH onto it to check the node-level logs.