### PR TITLE
Use db.t3.medium by default for RDS intances

### DIFF
--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -57,7 +57,7 @@ variable "name" {
 
 variable "node_type" {
   description = "AWS RDS instance type."
-  default     = "db.t2.medium"
+  default     = "db.t3.medium"
 }
 
 variable "parameter_group_name" {


### PR DESCRIPTION
The current generation is T3, so let’s use it as the default!