### PR TITLE
ADD security  group id to LB output

### DIFF
--- a/aws/application_load_balancer/outputs.tf
+++ b/aws/application_load_balancer/outputs.tf
@@ -18,3 +18,6 @@ output "https_listener_arn" {
   value = aws_alb_listener.https_listener.arn
 }
 
+output "securiy_group_id" {
+  value = aws_security_group.security_group_on_load_balancer.id
+}


### PR DESCRIPTION
NU requires explicit ingress/egress when defining routes between AWS services. We need access to the LB security group to add these explicit routes.