### PR TITLE
Allow roles to be attached to SES policy

### DIFF
--- a/aws/iam/ses_send/main.tf
+++ b/aws/iam/ses_send/main.tf
@@ -1,31 +1,24 @@
-resource "aws_iam_group" "mod" {
-  name = "ses_senders"
+data "aws_iam_policy_document" "mod" {
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+    actions = [
+      "ses:SendRawEmail",
+      "ses:SendEmail",
+    ]
+    resources = ["*"]
+  }
 }
 
-resource "aws_iam_group_policy" "mod" {
+resource "aws_iam_policy" "mod" {
   name  = "AmazonSesSendingAccess"
-  group = aws_iam_group.mod.id
 
-  policy = jsonencode(
-    {
-      Statement = [
-        {
-          Action = [
-            "ses:SendRawEmail",
-            "ses:SendEmail",
-          ]
-          Effect   = "Allow"
-          Resource = "*"
-        },
-      ]
-      Version = "2012-10-17"
-    }
-  )
+  policy = aws_iam_policy_document.mod.json
 }
 
-resource "aws_iam_group_membership" "mod" {
-  name  = "app-server-group-membership"
-  users = var.users
-  group = aws_iam_group.mod.name
+resource "aws_iam_policy_attachment" "mod" {
+  name       = "test-attachment"
+  users      = var.users
+  roles      = var.roles
+  policy_arn = aws_iam_policy.mod.arn
 }
-

--- a/aws/iam/ses_send/main.tf
+++ b/aws/iam/ses_send/main.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "mod" {
 resource "aws_iam_policy" "mod" {
   name  = "AmazonSesSendingAccess"
 
-  policy = aws_iam_policy_document.mod.json
+  policy = data.aws_iam_policy_document.mod.json
 }
 
 resource "aws_iam_policy_attachment" "mod" {

--- a/aws/iam/ses_send/main.tf
+++ b/aws/iam/ses_send/main.tf
@@ -17,7 +17,7 @@ resource "aws_iam_policy" "mod" {
 }
 
 resource "aws_iam_policy_attachment" "mod" {
-  name       = "test-attachment"
+  name       = "ses-sending-policy-attachment"
   users      = var.users
   roles      = var.roles
   policy_arn = aws_iam_policy.mod.arn

--- a/aws/iam/ses_send/outputs.tf
+++ b/aws/iam/ses_send/outputs.tf
@@ -1,4 +1,0 @@
-output "group_id" {
-  value = aws_iam_group.mod.id
-}
-

--- a/aws/iam/ses_send/variables.tf
+++ b/aws/iam/ses_send/variables.tf
@@ -1,4 +1,9 @@
 variable "users" {
   type = list(string)
+  default = []
 }
 
+variable "roles" {
+  type = list(string)
+  default = []
+}


### PR DESCRIPTION
Inspired by what we saw in the S3 module, this now uses `aws_iam_policy_attachment` rather than group membership so it supports both users and roles.

I grepped in the infrastructure repo and it doesn't look like anybody used the `group_id` output.

It will result in a good chunk of changes as clients upgrade the module.