### PR TITLE
Use exclude_names instead of blacklisted_names

### DIFF
--- a/aws/vpc/subnets/main.tf
+++ b/aws/vpc/subnets/main.tf
@@ -1,6 +1,6 @@
 # Find the available availability zones
 data "aws_availability_zones" "available" {
-  blacklisted_names = var.blacklisted_names
+  exclude_names = var.exclude_names
 }
 
 data "aws_vpc" "current" {

--- a/aws/vpc/subnets/variables.tf
+++ b/aws/vpc/subnets/variables.tf
@@ -21,7 +21,7 @@ variable "netnum_offset" {
   description = "Offset the subnets netnum by a specific amount."
 }
 
-variable "blacklisted_names" {
+variable "exclude_names" {
   default     = []
   description = "(Optional) List of blacklisted Availability Zone names."
 }


### PR DESCRIPTION
In version 3 of the AWS provider for Terraform, `blacklisted_names` on the `availability_zones` data source has been renamed to [`exclude_names`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones#argument-reference).

This PR updates our module for subnets, so that it can be used with v3 of the AWS provider.