### PR TITLE
Add aws/certificate module

### DIFF
--- a/aws/certificate/main.tf
+++ b/aws/certificate/main.tf
@@ -1,6 +1,11 @@
 locals {
+  domain_names_parts = {
+    for domain in var.domain_names: domain => split(".", domain)
+  }
+
   zone_names = {
-    for domain in var.domain_names: domain => join(".", slice(split(".", domain), 1, length(split(".", domain))))
+    for domain, parts in local.domain_names_parts:
+      domain => join(".", length(parts) > 2 ? slice(parts, 1, length(parts)) : parts)
   }
 }
 

--- a/aws/certificate/main.tf
+++ b/aws/certificate/main.tf
@@ -1,0 +1,39 @@
+locals {
+  zone_names = {
+    for domain in var.domain_names: domain => join(".", slice(split(".", domain), 1, length(split(".", domain))))
+  }
+}
+
+data "aws_route53_zone" "validation_zones" {
+  for_each = toset(values(local.zone_names))
+
+  name = each.value
+}
+
+resource "aws_acm_certificate" "certificate" {
+  domain_name               = var.domain_names[0]
+  subject_alternative_names = slice(var.domain_names, 1, length(var.domain_names))
+  validation_method         = "DNS"
+}
+
+resource "aws_route53_record" "validation_records" {
+  for_each = {
+    for dvo in aws_acm_certificate.certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.validation_zones[local.zone_names[each.key]].zone_id
+}
+
+resource "aws_acm_certificate_validation" "certificate_validation" {
+  certificate_arn         = aws_acm_certificate.certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.validation_records : record.fqdn]
+}

--- a/aws/certificate/outputs.tf
+++ b/aws/certificate/outputs.tf
@@ -1,0 +1,3 @@
+output "certificate_arn" {
+  value = aws_acm_certificate_validation.certificate_validation.certificate_arn
+}

--- a/aws/certificate/variables.tf
+++ b/aws/certificate/variables.tf
@@ -1,0 +1,4 @@
+variable "domain_names" {
+  description = "(Required) List of domain names for which the certificate should be issued. All domain names after the first one will be specified as subject alternative names."
+  type        = list(string)
+}


### PR DESCRIPTION
This PR introduces `aws/certificate` for handling DNS-validated AWS Certificate Manager certificates using v3 or newer of the AWS module for Terraform.

The module only requires a list of domain names for the certificate, and handles setting up validations and DNS records in the appropriate DNS zones (which it discovers via a data source).