### PR TITLE
Allow excluding availability zones on aws/eks

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -16,6 +16,7 @@ module "eks-vpc" {
 module "eks-subnets" {
   source = "../vpc/subnets"
 
+  exclude_names       = var.exclude_zones
   internet_gateway_id = module.eks-vpc.internet_gateway_id
   tags = merge(
     local.tags,

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -18,6 +18,11 @@ variable "ec2_ssh_key" {
   type        = string
 }
 
+variable "exclude_zones" {
+  default     = []
+  description = "(Optional) List of Availability Zone names to exclude."
+}
+
 variable "instance_type" {
   default = "t3.medium"
 }

--- a/aws/vpc/subnets/main.tf
+++ b/aws/vpc/subnets/main.tf
@@ -1,6 +1,7 @@
 # Find the available availability zones
 data "aws_availability_zones" "available" {
   exclude_names = var.exclude_names
+  state         = "available"
 }
 
 data "aws_vpc" "current" {

--- a/aws/vpc/subnets/main.tf
+++ b/aws/vpc/subnets/main.tf
@@ -1,7 +1,6 @@
 # Find the available availability zones
 data "aws_availability_zones" "available" {
   exclude_names = var.exclude_names
-  state         = "available"
 }
 
 data "aws_vpc" "current" {

--- a/aws/vpc/subnets/outputs.tf
+++ b/aws/vpc/subnets/outputs.tf
@@ -7,9 +7,5 @@ output "route_table_id" {
 }
 
 output "subnets_by_az" {
-  value = zipmap(
-    data.aws_availability_zones.available.names,
-    aws_subnet.mod[*].id,
-  )
+  value = { for subnet in aws_subnet.mod: subnet.availability_zone => subnet.id }
 }
-

--- a/aws/vpc/subnets/variables.tf
+++ b/aws/vpc/subnets/variables.tf
@@ -23,7 +23,7 @@ variable "netnum_offset" {
 
 variable "exclude_names" {
   default     = []
-  description = "(Optional) List of blacklisted Availability Zone names."
+  description = "(Optional) List of Availability Zone names to exclude."
 }
 
 variable "tags" {


### PR DESCRIPTION
This PR allows excluding availability zones from the EKS managed node group in `aws/eks`, to work around AWS limits for which instance types are supported in which zones.

Currently, because the list of subnets used for launching nodes is always all subnets in the VPC, we can get errors such as:

> Could not launch On-Demand Instances. Unsupported - Your requested instance type (t3.medium) is not supported in your requested Availability Zone (us-east-1a). Please retry your request by not specifying an Availability Zone or choosing us-east-1b, us-east-1c, us-east-1d, us-east-1e, us-east-1f. Launching EC2 instance failed.