### PR TITLE
[155405] Allow restricting elastiCache similar to RDS.

### DIFF
--- a/aws/elasticache/main.tf
+++ b/aws/elasticache/main.tf
@@ -1,5 +1,6 @@
 locals {
   version_major_minor_only = join(".", slice(split(".", var.engine_version), 0, 2))
+  table_xi_office_cidr_block  = "199.182.213.26/32"
 }
 
 locals {
@@ -82,6 +83,7 @@ resource "aws_security_group" "sg_on_elasticache_instance" {
   vpc_id      = var.vpc_id
 
   ingress {
+    cidr_blocks     = concat([local.table_xi_office_cidr_block], var.sg_cidr_blocks)
     from_port       = local.port
     to_port         = local.port
     protocol        = "tcp"

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -57,6 +57,11 @@ variable "security_groups_for_ingress" {
   default     = []
 }
 
+variable "sg_cidr_blocks" {
+  description = "cidr_blocks to give ElastiCache port access to."
+  default     = []
+}
+
 variable "subnets" {
   type = list(string)
 }


### PR DESCRIPTION
This allows us to specify a set of IP addresses that are permitted access to ElasticCache.
For use with k8s, where the SecurityGroup cannot be shared across VPC/AWS account

This should be able to be used by https://github.com/tablexi/infrastructure/pull/4159 to grant access to this redis instance to the staging k8s cluster