### PR TITLE
Refactor away interpolation-only expressions

### DIFF
--- a/aws/iam/datadog/main.tf
+++ b/aws/iam/datadog/main.tf
@@ -86,7 +86,7 @@ resource "aws_iam_role" "mod" {
         Action = "sts:AssumeRole"
         Condition = {
           StringEquals = {
-            "sts:ExternalId" = "${var.datadog_external_id}"
+            "sts:ExternalId" = var.datadog_external_id
           }
         }
         Effect = "Allow"


### PR DESCRIPTION
Interpolation-only expressions have been deprecated in Terraform 0.12, and are removed in version 0.13.

This PR removes the only such expression we have, so that our code can work on both version 0.12 and 0.13.