### PR TITLE
Revert "[155405] Allow restricting elastiCache similar to RDS."

### DIFF
--- a/aws/elasticache/main.tf
+++ b/aws/elasticache/main.tf
@@ -1,6 +1,5 @@
 locals {
   version_major_minor_only = join(".", slice(split(".", var.engine_version), 0, 2))
-  table_xi_office_cidr_block  = "199.182.213.26/32"
 }
 
 locals {
@@ -83,7 +82,6 @@ resource "aws_security_group" "sg_on_elasticache_instance" {
   vpc_id      = var.vpc_id
 
   ingress {
-    cidr_blocks     = concat([local.table_xi_office_cidr_block], var.sg_cidr_blocks)
     from_port       = local.port
     to_port         = local.port
     protocol        = "tcp"

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -57,11 +57,6 @@ variable "security_groups_for_ingress" {
   default     = []
 }
 
-variable "sg_cidr_blocks" {
-  description = "cidr_blocks to give ElastiCache port access to."
-  default     = []
-}
-
 variable "subnets" {
   type = list(string)
 }


### PR DESCRIPTION
Reverts tablexi/terraform_modules#176

I propose reverting this commit because based on [the documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/accessing-elasticache.html) this functionality doesn't permit access to the elasticache cluster like we had thought it would. Continuing to provide this option would serve to confuse.