### PR TITLE
Spin up CloudWatch for CloudTrail logs

### DIFF
--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -5,8 +5,8 @@ resource "aws_cloudtrail" "mod" {
   enable_logging                = true
   enable_log_file_validation    = true
 
-  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.mod.arn}:*"
-  cloud_watch_logs_role_arn     = aws_iam_role.cloudwatch.arn
+  cloud_watch_logs_group_arn    = var.cloud_watch_logs_group_arn
+  cloud_watch_logs_role_arn     = var.cloud_watch_logs_role_arn
 
   tags                          = var.tags
 }
@@ -22,31 +22,6 @@ resource "aws_s3_bucket" "mod" {
     target_bucket = "cloudtrail-logs"
     target_prefix = var.name
   }
-}
-
-resource "aws_cloudwatch_log_group" "mod" {
-  name = "${var.name}-cloudtrail-logs"
-}
-
-resource "aws_iam_role" "cloudwatch" {
-  name               = "${var.name}-cloudwatch"
-  path               = "/service-role/"
-  description        = "${var.name} cloudwatch logs role"
-  assume_role_policy = data.aws_iam_policy_document.assume-role.json
-
-  tags               = var.tags
-}
-
-resource "aws_iam_policy" "cloudwatch" {
-  name        = "${var.name}-cloudwatch-policy"
-  description = "${var.name} cloudwatch logs policy"
-  policy      = data.aws_iam_policy_document.cloudwatch.json
-}
-
-resource "aws_iam_policy_attachment" "mod" {
-  name       = "${var.name}-cloudwatch-attachment"
-  roles      = [aws_iam_role.cloudwatch.name]
-  policy_arn = aws_iam_policy.cloudwatch.arn
 }
 
 data "aws_iam_policy_document" "s3" {
@@ -75,30 +50,5 @@ data "aws_iam_policy_document" "s3" {
       type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]
     }
-  }
-}
-
-data "aws_iam_policy_document" "assume-role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["cloudtrail.amazonaws.com"]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "cloudwatch" {
-  statement {
-    sid       = "AWSCloudTrailCreateLogStream"
-    actions   = ["logs:CreateLogStream"]
-    resources = ["${aws_cloudwatch_log_group.mod.arn}:*"]
-  }
-
-  statement {
-    sid       = "AWSCloudTrailPutLogEvents"
-    actions   = ["logs:PutLogEvents"]
-    resources = ["${aws_cloudwatch_log_group.mod.arn}:*"]
   }
 }

--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -3,44 +3,102 @@ resource "aws_cloudtrail" "mod" {
   s3_bucket_name                = aws_s3_bucket.mod.id
   include_global_service_events = true
   enable_logging                = true
+  enable_log_file_validation    = true
+
+  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.mod.arn}:*"
+  cloud_watch_logs_role_arn     = aws_iam_role.cloudwatch.arn
+
   tags                          = var.tags
 }
 
 resource "aws_s3_bucket" "mod" {
   bucket = "${var.name}-cloudtrail"
   acl    = "private"
+  policy = data.aws_iam_policy_document.s3.json
 
-  policy = jsonencode(
-    {
-      Statement = [
-        {
-          Action = "s3:GetBucketAcl"
-          Effect = "Allow"
-          Principal = {
-            Service = "cloudtrail.amazonaws.com"
-          }
-          Resource = "arn:aws:s3:::${var.name}-cloudtrail"
-          Sid = "AWSCloudTrailAclCheck"
-        },
-        {
-          Action = "s3:PutObject"
-          Condition = {
-            StringEquals = {
-              "s3:x-amz-acl" = "bucket-owner-full-control"
-            }
-          }
-          Effect = "Allow"
-          Principal = {
-            Service = "cloudtrail.amazonaws.com"
-          }
-          Resource = "arn:aws:s3:::${var.name}-cloudtrail/*"
-          Sid = "AWSCloudTrailWrite"
-        },
-      ]
-      Version = "2012-10-17"
-    }
-  )
+  tags   = var.tags
 
-  tags = var.tags
+  logging {
+    target_bucket = "cloudtrail-logs"
+    target_prefix = var.name
+  }
 }
 
+resource "aws_cloudwatch_log_group" "mod" {
+  name = "${var.name}-cloudtrail-logs"
+}
+
+resource "aws_iam_role" "cloudwatch" {
+  name               = "${var.name}-cloudwatch"
+  path               = "/service-role/"
+  description        = "${var.name} cloudwatch logs role"
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
+
+  tags               = var.tags
+}
+
+resource "aws_iam_policy" "cloudwatch" {
+  name        = "${var.name}-cloudwatch-policy"
+  description = "${var.name} cloudwatch logs policy"
+  policy      = data.aws_iam_policy_document.cloudwatch.json
+}
+
+resource "aws_iam_policy_attachment" "mod" {
+  name       = "${var.name}-cloudwatch-attachment"
+  roles      = [aws_iam_role.cloudwatch.name]
+  policy_arn = aws_iam_policy.cloudwatch.arn
+}
+
+data "aws_iam_policy_document" "s3" {
+  statement {
+    sid       = "AWSCloudTrailAclCheck"
+    actions   = ["s3:GetBucketAcl"]
+    resources = ["arn:aws:s3:::${var.name}-cloudtrail"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+  }
+  statement {
+    sid       = "AWSCloudTrailWrite"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::${var.name}-cloudtrail/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "assume-role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch" {
+  statement {
+    sid       = "AWSCloudTrailCreateLogStream"
+    actions   = ["logs:CreateLogStream"]
+    resources = ["${aws_cloudwatch_log_group.mod.arn}:*"]
+  }
+
+  statement {
+    sid       = "AWSCloudTrailPutLogEvents"
+    actions   = ["logs:PutLogEvents"]
+    resources = ["${aws_cloudwatch_log_group.mod.arn}:*"]
+  }
+}

--- a/aws/cloudtrail/variables.tf
+++ b/aws/cloudtrail/variables.tf
@@ -8,3 +8,12 @@ variable "tags" {
   type        = map(string)
 }
 
+variable "cloud_watch_logs_group_arn" {
+  default     = ""
+  description = "(Optional) The ARN of a CloudWatch Log Group for the trail"
+}
+
+variable "cloud_watch_logs_role_arn" {
+  default     = ""
+  description = "(Optional) The ARN of a Role with CloudWatch permissions to attach"
+}

--- a/aws/cloudwatch/main.tf
+++ b/aws/cloudwatch/main.tf
@@ -1,0 +1,49 @@
+resource "aws_cloudwatch_log_group" "mod" {
+  name = "${var.name}-cloudwatch-logs"
+}
+
+resource "aws_iam_role" "mod" {
+  name               = "${var.name}-cloudwatch"
+  path               = "/service-role/"
+  description        = "${var.name} cloudwatch logs role"
+  assume_role_policy = data.aws_iam_policy_document.assume-role.json
+
+  tags               = var.tags
+}
+
+resource "aws_iam_policy" "mod" {
+  name        = "${var.name}-cloudwatch-policy"
+  description = "${var.name} cloudwatch logs policy"
+  policy      = data.aws_iam_policy_document.cloudwatch.json
+}
+
+resource "aws_iam_policy_attachment" "mod" {
+  name       = "${var.name}-cloudwatch-attachment"
+  roles      = [aws_iam_role.mod.name]
+  policy_arn = aws_iam_policy.mod.arn
+}
+
+data "aws_iam_policy_document" "assume-role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = var.services
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch" {
+  statement {
+    sid       = "AWSCloudWatchCreateLogStream"
+    actions   = ["logs:CreateLogStream"]
+    resources = ["${aws_cloudwatch_log_group.mod.arn}:*"]
+  }
+
+  statement {
+    sid       = "AWSCloudWatchPutLogEvents"
+    actions   = ["logs:PutLogEvents"]
+    resources = ["${aws_cloudwatch_log_group.mod.arn}:*"]
+  }
+}

--- a/aws/cloudwatch/outputs.tf
+++ b/aws/cloudwatch/outputs.tf
@@ -1,0 +1,7 @@
+output "group_arn" {
+  value = "${aws_cloudwatch_log_group.mod.arn}:*"
+}
+
+output "role_arn" {
+  value = aws_iam_role.mod.arn
+}

--- a/aws/cloudwatch/variables.tf
+++ b/aws/cloudwatch/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  description = "A prefix for the CloudWatch log group and roles"
+}
+
+variable "tags" {
+  default     = {}
+  description = "(Optional) A mapping of tags to assign to the resources"
+  type        = map(string)
+}
+
+variable "services" {
+  default     = []
+  description = "(Optional) The services to which CloudWatch should have access"
+  type        = list(string)
+}

--- a/aws/cloudwatch/versions.tf
+++ b/aws/cloudwatch/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
As a first step toward improving our AWS security defaults, we'd like
to enable CloudWatch any time we're spinning up a CloudTrail trail.
This will give us a lot of freedom moving forward to set up alerts,
monitoring, et cetera.

As part of this change, we're also making a few tweaks to our defaults
for the `cloudtrail` module:

- Enable logging for the CloudTrail log bucket
- Enable log file validation for CloudTrail logs
- Use an `aws_iam_policy_document` data source for our bucket policy

There are a few best practices we're _not_ going to try to implement
right now -- encrypting our log bucket with a KMS key, for instance.
But this should be a good step in the right direction to make security
a first-class citizen of our infrastructure management.

It's _entirely_ possible (even likely) that there are better ways to 
accomplish some of this, or a more appropriate way to organize these 
resources. This PR is primarily intended to start the conversation.
