### PR TITLE
Allow excluding AZs in the EKS VPC

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -16,6 +16,8 @@ module "eks-vpc" {
 module "eks-subnets" {
   source = "../vpc/subnets"
 
+  exclude_names = var.excluded_az_names
+
   internet_gateway_id = module.eks-vpc.internet_gateway_id
   tags = merge(
     local.tags,

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -26,6 +26,11 @@ variable "name" {
   description = "Name of the cluster"
 }
 
+variable "excluded_az_names" {
+  default     = []
+  description = "(Optional) List of Availability Zone names to exclude."
+}
+
 variable "tags" {
   description = "(Optional) A mapping of tags to assign to the resources"
   type        = map(string)

--- a/aws/vpc/subnets/outputs.tf
+++ b/aws/vpc/subnets/outputs.tf
@@ -8,7 +8,7 @@ output "route_table_id" {
 
 output "subnets_by_az" {
   value = zipmap(
-    data.aws_availability_zones.available.names,
+    aws_subnet.mod[*].availability_zone,
     aws_subnet.mod[*].id,
   )
 }


### PR DESCRIPTION
As a followup to #174, making the subnet module exclude by az name variable available to the eks module.