### PR TITLE
Create NAT Gateway for EKS traffic.

### DIFF
--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -25,4 +25,3 @@ output "subnets" {
 output "vpc_id" {
   value = module.eks-vpc.vpc_id
 }
-

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -13,6 +13,12 @@ variable "capacity_max" {
   default     = 6
 }
 
+variable "uses_nat_gateway" {
+  description = "Create a NAT Gateway for all outgoing internet traffic"
+  default     = false
+  type        = bool
+}
+
 variable "ec2_ssh_key" {
   description = "(Optional) EC2 Key Pair name that provides access for SSH communication with the worker nodes in the EKS Node Group."
   type        = string
@@ -31,7 +37,7 @@ variable "subnet_module" {
     exclude_names = list(string)
     netnum_offset = number
   })
-  default     = {
+  default = {
     exclude_names = []
     netnum_offset = 0
   }

--- a/aws/nat_gateway/main.tf
+++ b/aws/nat_gateway/main.tf
@@ -54,7 +54,7 @@ resource "aws_route_table" "mod" {
 resource "aws_route" "mod" {
   count                  = var.uses_nat_gateway ? 1 : 0
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_nat_gateway.gw[0].id
+  gateway_id             = var.internet_gateway_id
   route_table_id         = aws_route_table.mod[0].id
 }
 

--- a/aws/nat_gateway/main.tf
+++ b/aws/nat_gateway/main.tf
@@ -1,0 +1,65 @@
+# Create a single subnet for the NAT Gateway to live in
+# routed to the outside world
+
+data "aws_vpc" "current" {
+  id = var.vpc_id
+}
+
+# Create a subnet in us-east-1a in the
+# CIDR block specified by the inputs
+# So that the CIDR block is different than
+# others in this VPC
+resource "aws_subnet" "mod" {
+  count             = var.uses_nat_gateway ? 1 : 0
+  availability_zone = var.availability_zone
+  cidr_block = cidrsubnet(
+    data.aws_vpc.current.cidr_block,
+    var.subnet_cidr_newbits,
+    var.subnet_cidr_netnum_offset + 1,
+  )
+  map_public_ip_on_launch = true
+  tags                    = var.tags
+  vpc_id                  = var.vpc_id
+}
+
+
+# ElasticIP address for use with the NAT Gateway
+resource "aws_eip" "nat-gw-eip" {
+  count = var.uses_nat_gateway ? 1 : 0
+  vpc   = true
+  tags  = var.tags
+}
+
+# NAT Gateway in the first (only) subnet
+resource "aws_nat_gateway" "gw" {
+  count         = var.uses_nat_gateway ? 1 : 0
+  allocation_id = aws_eip.nat-gw-eip[0].id
+  subnet_id     = aws_subnet.mod[0].id
+
+  tags = merge(
+    var.tags,
+    {
+      Name = var.name
+    },
+  )
+  depends_on = [var.internet_gateway_id]
+}
+
+resource "aws_route_table" "mod" {
+  count  = var.uses_nat_gateway ? 1 : 0
+  tags   = var.tags
+  vpc_id = var.vpc_id
+}
+
+resource "aws_route" "mod" {
+  count                  = var.uses_nat_gateway ? 1 : 0
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_nat_gateway.gw[0].id
+  route_table_id         = aws_route_table.mod[0].id
+}
+
+resource "aws_route_table_association" "mod" {
+  count          = var.uses_nat_gateway ? 1 : 0
+  route_table_id = aws_route_table.mod[0].id
+  subnet_id      = aws_subnet.mod[0].id
+}

--- a/aws/nat_gateway/outputs.tf
+++ b/aws/nat_gateway/outputs.tf
@@ -1,0 +1,3 @@
+output "nat_gateway_id" {
+  value = var.uses_nat_gateway ? aws_nat_gateway.gw[0].id : -1
+}

--- a/aws/nat_gateway/variables.tf
+++ b/aws/nat_gateway/variables.tf
@@ -1,0 +1,37 @@
+variable "name" {
+  description = "Name of the gateway"
+}
+
+variable "vpc_id" {
+  description = "The unique ID of the VPC."
+}
+
+variable "tags" {
+  description = "(Optional) A mapping of tags to assign to the resources"
+  type        = map(string)
+}
+
+variable "internet_gateway_id" {
+  description = "Internet Gateway router for internet traffic"
+}
+
+variable "uses_nat_gateway" {
+  description = "Enable creation of this NAT Gateway and associated subnet/routes"
+  default     = false
+  type        = bool
+}
+
+variable "availability_zone" {
+  description = "Which AZ to create the NAT Gateway"
+  default     = "us-east-1a"
+}
+
+variable "subnet_cidr_newbits" {
+  default     = 8
+  description = "The subnets modifier of a routing mask or decrease the scope of the cidr_block by the given bits."
+}
+
+variable "subnet_cidr_netnum_offset" {
+  default     = 0
+  description = "Offset the subnets netnum by a specific amount."
+}

--- a/aws/vpc/subnets/main.tf
+++ b/aws/vpc/subnets/main.tf
@@ -15,7 +15,7 @@ resource "aws_route_table" "mod" {
 resource "aws_route" "mod" {
   count                  = var.public ? 1 : 0
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = var.internet_gateway_id
+  gateway_id             = var.gateway_id
   route_table_id         = aws_route_table.mod.id
 }
 

--- a/aws/vpc/subnets/variables.tf
+++ b/aws/vpc/subnets/variables.tf
@@ -2,8 +2,8 @@ variable "vpc_id" {
   description = "The unique ID of the VPC."
 }
 
-variable "internet_gateway_id" {
-  description = "The unique ID of the Internet gateway."
+variable "gateway_id" {
+  description = "The unique ID of the Internet (or NAT) gateway."
 }
 
 variable "public" {


### PR DESCRIPTION
Allow vpc subnets to route traffic to either internet gateway, or NAT gateway based on the `uses_nat_gateway` flag.

Note:
- This creates a new Subnet for the NAT Gateway to live in.
- It then creates a new Route Table, Route, and Route Table Association so that it routes NAT Gateway traffic through the internet_gateway

# Note

- Should this also expose the EIP in any way? (would that be useful to the consumer?)
- Is the creation of a new `aws_route_table` a problem? (if it is a problem, more extensive re-working of `vpc/subnets` is required in order to allow creation of `aws_route_table` before the creation of the `subnets`