### PR TITLE
Handle zones for domains of arbitrary length

### DIFF
--- a/aws/certificate/main.tf
+++ b/aws/certificate/main.tf
@@ -5,7 +5,7 @@ locals {
 
   zone_names = {
     for domain, parts in local.domain_names_parts:
-      domain => join(".", length(parts) > 2 ? slice(parts, 1, length(parts)) : parts)
+      domain => join(".", slice(parts, length(parts) - 2, length(parts)))
   }
 }
 


### PR DESCRIPTION
Since the zone should always just be the base domain name and its TLD,
we can more flexibly handle zones by just grabbing the last two parts
of the fully-qualified domain for which the certificate is being set
up. This would correctly give us `example.com` for a certificate on
`*.stage.example.com`, rather than the `stage.example.com` that
is currently computed, and should still work for all existing cases.