### PR TITLE
Fix interpolation-only expression warning

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -154,7 +154,7 @@ resource "aws_eks_node_group" "default" {
 }
 
 data "tls_certificate" "default" {
-  url = "${aws_eks_cluster.master.identity.0.oidc.0.issuer}"
+  url = aws_eks_cluster.master.identity.0.oidc.0.issuer
 }
 
 # IAM Service Account integration


### PR DESCRIPTION
Fixes the following Terraform warning:

> Warning: Interpolation-only expressions are deprecated
>
>  on .terraform/modules/staging/aws/eks/main.tf line 154, in data "tls_certificate" "default":
 154:   url = "${aws_eks_cluster.master.identity.0.oidc.0.issuer}"
>
> Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.
>
> Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
