### PR TITLE
Fix interpolation-only expression in eks/main.tf

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -166,5 +166,5 @@ resource "aws_iam_openid_connect_provider" "default" {
     "sts.amazonaws.com",
   ]
 
-  thumbprint_list = ["${data.tls_certificate.default.certificates.0.sha1_fingerprint}"]
+  thumbprint_list = [data.tls_certificate.default.certificates.0.sha1_fingerprint]
 }


### PR DESCRIPTION
I noticed this one today during an upgrade to Terraform 0.14