### PR TITLE
Fix interpolation-only warning in eks main

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -183,5 +183,5 @@ resource "aws_iam_openid_connect_provider" "default" {
     "sts.amazonaws.com",
   ]
 
-  thumbprint_list = ["${data.tls_certificate.default.certificates.0.sha1_fingerprint}"]
+  thumbprint_list = [data.tls_certificate.default.certificates.0.sha1_fingerprint]
 }


### PR DESCRIPTION
Fix interpolation-only expression warning
