### PR TITLE
Change NAT gateway module to create a separate subnet for each AZ.

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -16,11 +16,12 @@ module "eks-vpc" {
 module "eks-vpc-nat-gateway" {
   source = "../nat_gateway"
 
-  uses_nat_gateway          = var.uses_nat_gateway
-  internet_gateway_id       = module.eks-vpc.internet_gateway_id
-  name                      = var.name
-  vpc_id                    = module.eks-vpc.vpc_id
-  subnet_cidr_netnum_offset = 100 # So that it doesn't vary based on capacity
+  uses_nat_gateway           = var.uses_nat_gateway
+  exclude_availability_zones = var.subnet_module.exclude_names
+  internet_gateway_id        = module.eks-vpc.internet_gateway_id
+  name                       = var.name
+  vpc_id                     = module.eks-vpc.vpc_id
+  subnet_cidr_netnum_offset  = 100 # So that it doesn't vary based on capacity
 
   tags = merge(
     local.tags,
@@ -36,7 +37,9 @@ module "eks-subnets" {
   exclude_names = var.subnet_module.exclude_names
   netnum_offset = var.subnet_module.netnum_offset
 
-  gateway_id = var.uses_nat_gateway ? module.eks-vpc-nat-gateway.nat_gateway_id : module.eks-vpc.internet_gateway_id
+  internet_gateway_id = module.eks-vpc.internet_gateway_id
+  nat_gateway_id = var.uses_nat_gateway ? module.eks-vpc-nat-gateway.nat_gateway_id : 0
+
   tags = merge(
     local.tags,
     {

--- a/aws/nat_gateway/main.tf
+++ b/aws/nat_gateway/main.tf
@@ -1,27 +1,26 @@
-# Create a single subnet for the NAT Gateway to live in
-# routed to the outside world
+# Create subnets for use by the LoadBalancer for ingress
+# And use the first of these subnets for the NAT Gateway
+
+data "aws_availability_zones" "available" {
+  exclude_names = var.exclude_availability_zones
+}
 
 data "aws_vpc" "current" {
   id = var.vpc_id
 }
 
-# Create a subnet in us-east-1a in the
-# CIDR block specified by the inputs
-# So that the CIDR block is different than
-# others in this VPC
 resource "aws_subnet" "mod" {
-  count             = var.uses_nat_gateway ? 1 : 0
-  availability_zone = var.availability_zone
+  count             = var.uses_nat_gateway ? length(data.aws_availability_zones.available.names) : 0
+  availability_zone = element(data.aws_availability_zones.available.names, count.index)
   cidr_block = cidrsubnet(
     data.aws_vpc.current.cidr_block,
     var.subnet_cidr_newbits,
-    var.subnet_cidr_netnum_offset + 1,
+    var.subnet_cidr_netnum_offset + count.index + 1,
   )
   map_public_ip_on_launch = true
   tags                    = var.tags
   vpc_id                  = var.vpc_id
 }
-
 
 # ElasticIP address for use with the NAT Gateway
 resource "aws_eip" "nat-gw-eip" {
@@ -30,7 +29,7 @@ resource "aws_eip" "nat-gw-eip" {
   tags  = var.tags
 }
 
-# NAT Gateway in the first (only) subnet
+# NAT Gateway in the first subnet
 resource "aws_nat_gateway" "gw" {
   count         = var.uses_nat_gateway ? 1 : 0
   allocation_id = aws_eip.nat-gw-eip[0].id
@@ -59,7 +58,7 @@ resource "aws_route" "mod" {
 }
 
 resource "aws_route_table_association" "mod" {
-  count          = var.uses_nat_gateway ? 1 : 0
+  count          = var.uses_nat_gateway ? length(data.aws_availability_zones.available.names) : 0
   route_table_id = aws_route_table.mod[0].id
-  subnet_id      = aws_subnet.mod[0].id
+  subnet_id      = element(aws_subnet.mod[*].id, count.index)
 }

--- a/aws/nat_gateway/variables.tf
+++ b/aws/nat_gateway/variables.tf
@@ -21,9 +21,10 @@ variable "uses_nat_gateway" {
   type        = bool
 }
 
-variable "availability_zone" {
-  description = "Which AZ to create the NAT Gateway"
-  default     = "us-east-1a"
+variable "exclude_availability_zones" {
+  description = "Which AZ(s) should NOT be used (all other zones will have a subnet created)"
+  type        = list(string)
+  default     = []
 }
 
 variable "subnet_cidr_newbits" {

--- a/aws/vpc/subnets/main.tf
+++ b/aws/vpc/subnets/main.tf
@@ -12,10 +12,13 @@ resource "aws_route_table" "mod" {
   vpc_id = var.vpc_id
 }
 
+# no nat-gateway, create with internet_gateway
+# nat-gateway, create with nat_gateway, not internet_gateway
 resource "aws_route" "mod" {
   count                  = var.public ? 1 : 0
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = var.gateway_id
+  gateway_id             = var.nat_gateway_id == 0 ? var.internet_gateway_id : null
+  nat_gateway_id         = var.nat_gateway_id == 0 ? null : var.nat_gateway_id
   route_table_id         = aws_route_table.mod.id
 }
 

--- a/aws/vpc/subnets/variables.tf
+++ b/aws/vpc/subnets/variables.tf
@@ -2,8 +2,13 @@ variable "vpc_id" {
   description = "The unique ID of the VPC."
 }
 
-variable "gateway_id" {
-  description = "The unique ID of the Internet (or NAT) gateway."
+variable "internet_gateway_id" {
+  description = "The unique ID of the Internet gateway."
+}
+
+variable "nat_gateway_id" {
+  description = "The ID of the NAT Gateway (if applicable)"
+  default = 0
 }
 
 variable "public" {


### PR DESCRIPTION
These subnets will be used by the k8s LoadBalancer for its ingress targets,
because we want to put the k8s nodes themselves in private subnets, which route
to the NAT gateway for egress.

This also adjusts the syntax for using aws_route, since there is 'gateway_id'
and also 'nat_gateway_id', so we use the proper attribute at the proper time.

I was not able to use the vpc/subnets module to do the NAT-gateway-subnets creation
because you cannot use 'count' arguments with 'modules', and thus using the
'uses_nat_gateway' option to enable/disable the nat-gateway creation requires
that that module NOT depend on other modules.