### PR TITLE
Refactor conditional creation of NAT gateway for EKS

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -16,12 +16,12 @@ module "eks-vpc" {
 module "eks-vpc-nat-gateway" {
   source = "../nat_gateway"
 
-  uses_nat_gateway           = var.uses_nat_gateway
+  count                      = var.uses_nat_gateway ? 1 : 0
   exclude_availability_zones = var.subnet_module.exclude_names
   internet_gateway_id        = module.eks-vpc.internet_gateway_id
   name                       = var.name
-  vpc_id                     = module.eks-vpc.vpc_id
   subnet_cidr_netnum_offset  = 100 # So that it doesn't vary based on capacity
+  vpc_id                     = module.eks-vpc.vpc_id
 
   tags = merge(
     local.tags,
@@ -38,7 +38,7 @@ module "eks-subnets" {
   netnum_offset = var.subnet_module.netnum_offset
 
   internet_gateway_id = module.eks-vpc.internet_gateway_id
-  nat_gateway_id = var.uses_nat_gateway ? module.eks-vpc-nat-gateway.nat_gateway_id : 0
+  nat_gateway_id = var.uses_nat_gateway ? module.eks-vpc-nat-gateway[0].nat_gateway_id : 0
 
   tags = merge(
     local.tags,

--- a/aws/nat_gateway/outputs.tf
+++ b/aws/nat_gateway/outputs.tf
@@ -1,3 +1,3 @@
 output "nat_gateway_id" {
-  value = var.uses_nat_gateway ? aws_nat_gateway.gw[0].id : -1
+  value = aws_nat_gateway.gw.id
 }

--- a/aws/nat_gateway/variables.tf
+++ b/aws/nat_gateway/variables.tf
@@ -15,12 +15,6 @@ variable "internet_gateway_id" {
   description = "Internet Gateway router for internet traffic"
 }
 
-variable "uses_nat_gateway" {
-  description = "Enable creation of this NAT Gateway and associated subnet/routes"
-  default     = false
-  type        = bool
-}
-
 variable "exclude_availability_zones" {
   description = "Which AZ(s) should NOT be used (all other zones will have a subnet created)"
   type        = list(string)


### PR DESCRIPTION
In the Terraform module `aws/nat_gateway`, all resources used have a conditional `count` attribute, which is dependent on the variable `uses_nat_gateway`: if the variable is false, `count = 0`, and otherwise count is set to a value that creates resources.

This PR refactors the conditional creation to be specified on the entire `module` declaration itself (which is [available since Terraform 0.13](https://www.terraform.io/docs/language/meta-arguments/count.html)), in order to simplify the code inside the module itself. The end result is the same, although any users of the module might need to do `state mv` operations because the internal Terraform address of the resources changes (things that used to be `module.eks-vpc-nat-gateway.aws_eip.nat-gw-eip[0]` are now `module.eks-vpc-nat-gateway[0].aws_eip.nat-gw-eip`, for example).