### PR TITLE
Add tags to EKS-related subnets to support discovery for ELB

### DIFF
--- a/aws/nat_gateway/main.tf
+++ b/aws/nat_gateway/main.tf
@@ -1,3 +1,7 @@
+locals {
+  subnet_tags = merge(var.tags, { "kubernetes.io/role/elb" = true })
+}
+
 # Create subnets for use by the LoadBalancer for ingress
 # And use the first of these subnets for the NAT Gateway
 
@@ -18,14 +22,14 @@ resource "aws_subnet" "mod" {
     var.subnet_cidr_netnum_offset + count.index + 1,
   )
   map_public_ip_on_launch = true
-  tags                    = var.tags
+  tags                    = local.subnet_tags
   vpc_id                  = var.vpc_id
 }
 
 # ElasticIP address for use with the NAT Gateway
 resource "aws_eip" "nat-gw-eip" {
-  vpc   = true
-  tags  = var.tags
+  vpc  = true
+  tags = var.tags
 }
 
 # NAT Gateway in the first subnet


### PR DESCRIPTION
This PR implements the guidance in https://aws.amazon.com/premiumsupport/knowledge-center/eks-vpc-subnet-discovery/ around how to tag subnets in AWS, so that load balancers created for the purposes of EKS clusters can correctly choose subnets to be associated with.

In particular, the scheme we implement is:
- In the NAT gateway module, since all the subnets we create are public, we tag them with `kubernetes.io/role/elb`.
- In the EKS module, if we are using a NAT gateway (meaning the subnets we create for EKS nodes are private), we tag the subnets with `kubernetes.io/role/internal-elb`. Otherwise (the subnets we create for EKS are public) we tag the subnets with `kubernetes.io/role/elb`.

The effect of these tags is that load balancers created by the cloud controller manager (to satisfy Service objects with `type: LoadBalancer`) or the ALB ingress controller are placed in the appropriate subnets. For us, at the time of this writing all load balancers are public, so we expect them to be created in the subnets tagged with `kubernetes.io/role/elb`.