### PR TITLE
Create unique logging bucket for Cloudtrail module

### DIFF
--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -5,17 +5,17 @@ resource "aws_cloudtrail" "mod" {
   enable_logging                = true
   enable_log_file_validation    = true
 
-  cloud_watch_logs_group_arn    = var.cloud_watch_logs_group_arn
-  cloud_watch_logs_role_arn     = var.cloud_watch_logs_role_arn
+  cloud_watch_logs_group_arn = var.cloud_watch_logs_group_arn
+  cloud_watch_logs_role_arn  = var.cloud_watch_logs_role_arn
 
-  tags                          = var.tags
+  tags = var.tags
 }
 
 resource "aws_s3_bucket" "logs" {
-  bucket = "${var.name}-cloudtrail-logs"
-  acl    = "log-delivery-write"
+  bucket_prefix = "${var.name}-cloudtrail-logs"
+  acl           = "log-delivery-write"
 
-  tags   = var.tags
+  tags = var.tags
 }
 
 resource "aws_s3_bucket" "mod" {
@@ -23,7 +23,7 @@ resource "aws_s3_bucket" "mod" {
   acl    = "private"
   policy = data.aws_iam_policy_document.s3.json
 
-  tags   = var.tags
+  tags = var.tags
 
   logging {
     target_bucket = aws_s3_bucket.logs.id

--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -11,6 +11,13 @@ resource "aws_cloudtrail" "mod" {
   tags                          = var.tags
 }
 
+resource "aws_s3_bucket" "logs" {
+  bucket = "${var.name}-cloudtrail-logs"
+  acl    = "log-delivery-write"
+
+  tags   = var.tags
+}
+
 resource "aws_s3_bucket" "mod" {
   bucket = "${var.name}-cloudtrail"
   acl    = "private"
@@ -19,7 +26,7 @@ resource "aws_s3_bucket" "mod" {
   tags   = var.tags
 
   logging {
-    target_bucket = "cloudtrail-logs"
+    target_bucket = aws_s3_bucket.logs.id
     target_prefix = var.name
   }
 }


### PR DESCRIPTION
Monitoring changes to the Cloudtrail bucket requires the logging
bucket to pre-exist, so we need to generate it here. This ensures that
the end-to-end process works properly.