### PR TITLE
Output VPC and Security Groups for outside of EKS usage

### DIFF
--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -18,6 +18,10 @@ output "node_instance_role" {
   value = aws_iam_role.nodes.arn
 }
 
+output "cluster_security_group_id" {
+  value = aws_eks_cluster.master.vpc_config[0].cluster_security_group_id
+}
+
 output "oidc_provider" {
   value = aws_iam_openid_connect_provider.default.arn
 }

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -33,3 +33,7 @@ output "eks-vpc" {
 output "elastic_ip" {
   value = var.uses_nat_gateway ? module.eks-vpc-nat-gateway[0].elastic_ip : null
 }
+
+output "vpc" {
+  value = module.eks-vpc
+}


### PR DESCRIPTION
I reverted an earlier commit because it was going to make us reissue certificates and it seemed to be a convenience instead of something necessary. Happy to put it back/rebase if we can figure out a safe way to do it.