### PR TITLE
Improve granularity of control for EKS module

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -11,6 +11,7 @@ locals {
 module "eks-vpc" {
   source = "../vpc"
 
+  cidr = var.vpc_cidr
   tags = merge(
     local.tags,
     {

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -2,6 +2,10 @@ output "cluster_arn" {
   value = aws_eks_cluster.master.arn
 }
 
+output "cluster_security_group_id" {
+  value = aws_eks_cluster.master.vpc_config[0].cluster_security_group_id
+}
+
 output "main_oidc_identity" {
   value = aws_eks_cluster.master.identity[0].oidc[0].issuer
 }

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -30,6 +30,10 @@ output "vpc_id" {
   value = module.eks-vpc.vpc_id
 }
 
+output "vpc_cidr_block" {
+  value = module.eks-vpc.cidr_block
+}
+
 output "elastic_ip" {
   value = var.uses_nat_gateway ? module.eks-vpc-nat-gateway[0].elastic_ip : null
 }

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -44,6 +44,11 @@ variable "subnet_module" {
   description = "(Optional) Expose some subnet module variables to root module"
 }
 
+variable "vpc_cidr" {
+  description = "(Optional) The CIDR block for the VPC."
+  default     = "10.0.0.0/16"
+}
+
 variable "tags" {
   description = "(Optional) A mapping of tags to assign to the resources"
   type        = map(string)


### PR DESCRIPTION
Being able to manipulate the underlying VPC's CIDR block for a cluster is useful for many reasons, particularly in VPC peering configurations, which don't allow for conflicting IP ranges. Since the VPC module already exposes this, I just added a pass-through variable to the EKS module to allow the range to be specified manually.

There seems to be a bit of overlap here with https://github.com/tablexi/terraform_modules/pull/193, since the work I'm basing off of this branch needs to access the cluster's security group to assign to rules on resources in the peered VPC.