### PR TITLE
ADD eks-vpc to output

### DIFF
--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -30,14 +30,6 @@ output "eks-vpc" {
   value = module.eks-vpc
 }
 
-output "vpc_id" {
-  value = module.eks-vpc.vpc_id
-}
-
-output "vpc_cidr_block" {
-  value = module.eks-vpc.cidr_block
-}
-
 output "elastic_ip" {
   value = var.uses_nat_gateway ? module.eks-vpc-nat-gateway[0].elastic_ip : null
 }

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -26,6 +26,10 @@ output "subnets" {
   value = module.eks-subnets.subnets
 }
 
+output "eks-vpc" {
+  value = module.eks-vpc
+}
+
 output "vpc_id" {
   value = module.eks-vpc.vpc_id
 }


### PR DESCRIPTION
At some point between v12 and v14, terraform removed the ability to reference nested modules directly and access its outputs (EXAMPLE `module.something.nested_module.output`). This was great, but it is no longer and we have to explicetly define it is as an output. This PR does that for the eks-vpc module.
