### PR TITLE
Simplify handling of parameter groups in aws/database_replica

### DIFF
--- a/aws/database_replica/outputs.tf
+++ b/aws/database_replica/outputs.tf
@@ -6,10 +6,6 @@ output "env" {
   value = var.env
 }
 
-output "family" {
-  value = local.family
-}
-
 output "name" {
   value = var.name
 }

--- a/aws/database_replica/variables.tf
+++ b/aws/database_replica/variables.tf
@@ -13,11 +13,6 @@ variable "env" {
   default     = "production"
 }
 
-variable "engine_version" {
-  description = "Engine version. Defaults to the version of the source database."
-  default     = ""
-}
-
 variable "identifier" {
   description = "Set the identifier for the instance"
   default     = ""


### PR DESCRIPTION
Removes unused variables and locals, and always sets the parameter group name based on the source database.

This results in simpler code overall, and fixes a problem with our string mangling in order to extract a version number, so that we can build a string for AWS’s default parameter group names: with the move to PostgreSQL 12, the major version is just a single number, whereas before with 9.6, it was two numbers. Therefore, our existing code computed a default parameter group name of `default.postgres12.5`, when it should have been `default.postgres12`.

Instead of tweaking the string splitting and rejoining, it’s simpler to always follow the source database’s lead here.