### PR TITLE
Increase default storage size for RDS instances to 20GB

### DIFF
--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -92,7 +92,7 @@ variable "source_db" {
 
 variable "storage" {
   description = "Volume storage size for the RDS instance in gigabytes."
-  default     = 5
+  default     = 20
 }
 
 variable "storage_encrypted" {


### PR DESCRIPTION
Increases our default RDS storage size from 5GB to 20GB, to avoid problems with instances running out of disk space. PostgreSQL 12 seems to have a larger footprint than previous versions we were upgrading from, and with 5GB storage we are cutting it very close for comfort. The 15GB increase is about $1.5/month for `gp2`-type instances, which is the type for all instances where we use the default.