### PR TITLE
Add multi_az_enabled argument to aws/elasticache

### DIFF
--- a/aws/elasticache/main.tf
+++ b/aws/elasticache/main.tf
@@ -42,6 +42,7 @@ resource "aws_elasticache_replication_group" "mod" {
   count                         = local.elasticache_replication_group ? 1 : 0
   engine_version                = var.engine_version
   maintenance_window            = var.maintenance_window
+  multi_az_enabled              = var.multi_az_enabled
   node_type                     = var.node_type
   number_cache_clusters         = var.num_nodes
   parameter_group_name          = aws_elasticache_parameter_group.mod[0].id

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -32,6 +32,11 @@ variable "maintenance_window" {
   description = "Set the weekly maintenance window for the cluster. The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC)"
 }
 
+variable "multi_az_enabled" {
+  default     = false
+  description = "(Optional) Specifies whether to enable Multi-AZ Support for the replication group. If true, automatic_failover_enabled must also be enabled. Defaults to false."
+}
+
 variable "name" {
 }
 


### PR DESCRIPTION
The argument `multi_az_enabled` on a `aws_elasticache_replication_group` has been [available since v3.26.0 of the `aws` provider](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.26.0), and it goes in tandem with the argument `automatic_failover_enabled`, which we support.

This PR adds support for `multi_az_enabled`, so that instances where we set `automatic_failover_enabled` can match the configuration in AWS (so far, `multi_az_enabled` wasn’t a part of Terraform’s API, so it didn’t appear in plans/diffs).