### PR TITLE
ADD dd readable cluster_name

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -1,6 +1,6 @@
 locals {
   elb_discovery_tag = var.uses_nat_gateway ? "kubernetes.io/role/internal-elb" : "kubernetes.io/role/elb"
-  tags              = merge({ Name = var.name }, var.tags)
+  tags              = merge({ Name = var.name, eks_cluster_name = var.name }, var.tags)
 
   subnet_tags = merge(local.tags, {
     (local.elb_discovery_tag)           = true,


### PR DESCRIPTION
DataDog has issues reading AWS tag keys with ":" in them. This is probably due to the fact that they rely on ":" to seperate their tag key:value internally. https://docs.datadoghq.com/getting_started/tagging/#defining-tags Due to this we can't use the built in EKS generated tags for `eks:cluster_name`. This solves this by introducing a new `eks_cluster_name` (Super fancy I know) key.
