### PR TITLE
ADD cluster autoscaler to EKS

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -251,7 +251,7 @@ data "aws_iam_policy_document" "cluster-autoscaler" {
 
 resource "aws_iam_role" "cluster-autoscaler" {
   count = var.uses_cluster_autoscaler ? 1 : 0
-  name  = "ClusterAutoscaler"
+  name  = "cluster-autoscaler-${var.name}"
 
   assume_role_policy = data.aws_iam_policy_document.cluster-autoscaler-trust-relationship.json
 }

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -251,7 +251,7 @@ data "aws_iam_policy_document" "cluster-autoscaler" {
 
 resource "aws_iam_role" "cluster-autoscaler" {
   count = var.uses_cluster_autoscaler ? 1 : 0
-  name  = "cluster-autoscaler-${var.name}"
+  name  = "cluster-autoscaler-${var.name}-serviceaccount"
 
   assume_role_policy = data.aws_iam_policy_document.cluster-autoscaler-trust-relationship.json
 }

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -162,10 +162,10 @@ resource "aws_iam_role_policy_attachment" "nodes-AmazonEC2ContainerRegistryReadO
 resource "random_id" "node-group-name" {
   prefix = "default-"
   keepers = {
-    capacity_type = var.capacity_type
-    ec2_ssh_key = var.ec2_ssh_key
-    instance_types = var.instance_types
-    subnet_ids = module.eks-subnets.subnets
+    capacity_type  = var.capacity_type
+    ec2_ssh_key    = var.ec2_ssh_key
+    instance_types = join(", ", var.instance_types)
+    subnet_ids     = join(", ", module.eks-subnets.subnets)
   }
   byte_length = 12
 }

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -189,7 +189,8 @@ resource "aws_eks_node_group" "default" {
   # This is the only way to allow the node group to scale independently of the terraform state.
   # We can use terraform to define the descired_size to start, but don't want to impede any other scaling mechanisms.
   lifecycle {
-    ignore_changes = [scaling_config[0].desired_size]
+    ignore_changes        = [scaling_config[0].desired_size]
+    create_before_destroy = true
   }
 }
 

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -259,7 +259,7 @@ resource "aws_iam_role" "cluster-autoscaler" {
 resource "aws_iam_role_policy" "cluster-autoscaler-policy" {
   count = var.uses_cluster_autoscaler ? 1 : 0
   name  = "${var.name}ClusterAutoscalerPolicy"
-  role  = aws_iam_role.cluster-autoscaler.id
+  role  = aws_iam_role.cluster-autoscaler[0].id
 
   policy = data.aws_iam_policy_document.cluster-autoscaler.json
 }

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -175,7 +175,7 @@ resource "aws_eks_node_group" "default" {
   capacity_type   = var.capacity_type
   instance_types  = var.instance_types
   disk_size       = var.disk_size
-  node_group_name = random_id.node-group-name.b64_url 
+  node_group_name = random_id.node-group-name.b64_url
   node_role_arn   = aws_iam_role.nodes.arn
   tags            = local.node_group_tags
 

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -158,7 +158,8 @@ resource "aws_iam_role_policy_attachment" "nodes-AmazonEC2ContainerRegistryReadO
 
 resource "aws_eks_node_group" "default" {
   cluster_name    = var.name
-  instance_types  = [var.instance_type]
+  capacity_type   = var.capacity_type
+  instance_types  = var.instance_types
   disk_size       = var.disk_size
   node_group_name = "default"
   node_role_arn   = aws_iam_role.nodes.arn

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -175,7 +175,7 @@ resource "aws_eks_node_group" "default" {
   capacity_type   = var.capacity_type
   instance_types  = var.instance_types
   disk_size       = var.disk_size
-  node_group_name = random_id.node-group-name.id
+  node_group_name = random_id.node-group-name.b64_url 
   node_role_arn   = aws_iam_role.nodes.arn
   tags            = local.node_group_tags
 

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -226,7 +226,7 @@ data "aws_iam_policy_document" "cluster-autoscaler-trust-relationship" {
     condition {
       test     = "StringEquals"
       variable = "${trimprefix(aws_eks_cluster.main.identity[0].oidc[0].issuer, "https://")}:sub"
-      values   = ["system:serviceaccount:cert-manager:cert-manager"]
+      values   = ["system:serviceaccount:${var.cluster_autoscaler.namespace}:${var.cluster_autoscaler.serviceaccount}"]
     }
   }
 }

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -33,3 +33,7 @@ output "eks-vpc" {
 output "elastic_ip" {
   value = var.uses_nat_gateway ? module.eks-vpc-nat-gateway[0].elastic_ip : null
 }
+
+output "cluster_autoscaler_role_arn" {
+  value = var.uses_cluster_autoscaler ? aws_iam_role.cluster-autoscaler[0].arn : null
+}

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -45,8 +45,16 @@ variable "disk_size" {
   type        = number
 }
 
-variable "instance_type" {
-  default = "t3.medium"
+variable "capacity_type" {
+  description = "Node group capacity type"
+  default     = "ON_DEMAND"
+  type        = string
+}
+
+variable "instance_types" {
+  description = "List of instance types to associate with the node group"
+  default     = ["t3.medium"]
+  type        = list(string)
 }
 
 variable "name" {

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -19,6 +19,12 @@ variable "uses_nat_gateway" {
   type        = bool
 }
 
+variable "uses_cluster_autoscaler" {
+  description = "Update node group tags and create IAM role with autoscale group credentials"
+  default     = false
+  type        = bool
+}
+
 variable "ec2_ssh_key" {
   description = "(Optional) EC2 Key Pair name that provides access for SSH communication with the worker nodes in the EKS Node Group."
   type        = string

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -25,6 +25,15 @@ variable "uses_cluster_autoscaler" {
   type        = bool
 }
 
+variable "cluster_autoscaler" {
+  description = "Cluster autoscaler namespace name"
+  default = {
+    namespace = "kube-system"
+    serviceaccount = "cluster-autoscaler"
+  }
+  type = map(string)
+}
+
 variable "ec2_ssh_key" {
   description = "(Optional) EC2 Key Pair name that provides access for SSH communication with the worker nodes in the EKS Node Group."
   type        = string

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -28,7 +28,7 @@ variable "uses_cluster_autoscaler" {
 variable "cluster_autoscaler" {
   description = "Cluster autoscaler namespace name"
   default = {
-    namespace = "kube-system"
+    namespace      = "kube-system"
     serviceaccount = "cluster-autoscaler"
   }
   type = map(string)


### PR DESCRIPTION
This adds a bunch of capabilities to the EKS module related to cluster autoscaling using the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html) as a guide.

1. Add tags to the Kubernetes Node Group (AWS Autoscaling Group) to allow the cluster-autoscaler to discover and control the number of nodes in the cluster.
2. Create the serviceaccount role and policy.
3. Add ability to use multiple instance types and spot instances during node group generation.
4. Allow for destruction of node groups without impacting the cluster by creating a new node group (with a different name) when changes that require a recreation are detected.