### PR TITLE
Refactor away use of deprecated list() function

### DIFF
--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -11,7 +11,7 @@ resource "aws_instance" "mod" {
   ami                         = var.ami
   instance_type               = var.type
   key_name                    = var.key_name
-  vpc_security_group_ids      = concat(list(aws_security_group.security_group_on_instances.id), var.vpc_security_group_ids)
+  vpc_security_group_ids      = concat([aws_security_group.security_group_on_instances.id], var.vpc_security_group_ids)
   subnet_id                   = element(var.subnets, count.index)
   associate_public_ip_address = true
   iam_instance_profile        = var.iam_instance_profile


### PR DESCRIPTION
Attempting to use this module with Terraform 0.15 gives the error:

```
╷
│ Error: Error in function call
│ 
│   on .terraform/modules/production-servers/aws/ec2/main.tf line 14, in resource "aws_instance" "mod":
│   14:   vpc_security_group_ids      = concat(list(aws_security_group.security_group_on_instances.id), var.vpc_security_group_ids)
│     ├────────────────
│     │ aws_security_group.security_group_on_instances.id will be known only after apply
│ 
│ Call to function "list" failed: the "list" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to write a
│ literal list.
╵
```

This PR fixes the error by using `concat` with a literal instead of using `list()`, which no longer exists. This works with both Terraform 0.14 and 0.15.