### PR TITLE
Introduce aws/eks_node_group module

### DIFF
--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -37,3 +37,15 @@ output "elastic_ip" {
 output "cluster_autoscaler_role_arn" {
   value = var.uses_cluster_autoscaler ? aws_iam_role.cluster-autoscaler[0].arn : null
 }
+
+output "uses_cluster_autoscaler" {
+  value = var.uses_cluster_autoscaler
+}
+
+output "tags" {
+  value = aws_eks_cluster.main.tags
+}
+
+output "name" {
+  value = aws_eks_cluster.main.name
+}

--- a/aws/eks_node_group/main.tf
+++ b/aws/eks_node_group/main.tf
@@ -1,0 +1,83 @@
+locals {
+  # Node Group Cluster Autoscaler prerequisites
+  # https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html#ca-prerequisites
+  cluster_autoscaler_tags = {
+    "k8s.io/cluster-autoscaler/${var.cluster.name}" = "owned",
+    "k8s.io/cluster-autoscaler/enabled"             = "TRUE"
+  }
+
+  node_group_tags = var.cluster.uses_cluster_autoscaler ? merge(var.cluster.tags, local.cluster_autoscaler_tags) : var.cluster.tags
+}
+
+data "aws_iam_policy_document" "nodes_assume_role_policy" {
+  version = "2012-10-17"
+
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "nodes" {
+  name_prefix        = var.node_group_name_prefix
+  assume_role_policy = data.aws_iam_policy_document.nodes_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "nodes-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "nodes-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "nodes-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_eks_node_group" "nodes" {
+  ami_type               = var.ami_type
+  capacity_type          = var.capacity_type
+  cluster_name           = var.cluster.name
+  disk_size              = var.disk_size
+  instance_types         = var.instance_types
+  node_group_name_prefix = var.node_group_name_prefix
+  node_role_arn          = aws_iam_role.nodes.arn
+  tags                   = local.node_group_tags
+
+  remote_access {
+    ec2_ssh_key = var.ec2_ssh_key
+  }
+
+  scaling_config {
+    desired_size = var.desired_size
+    max_size     = var.max_size
+    min_size     = var.min_size
+  }
+
+  subnet_ids = var.subnet_ids
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    var.cluster,
+    aws_iam_role_policy_attachment.nodes-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.nodes-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.nodes-AmazonEC2ContainerRegistryReadOnly,
+  ]
+
+  # Do not detect Terraform drift for the desired size, so that the node group’s
+  # size can change outside of Terraform as necessary.
+  lifecycle {
+    ignore_changes = [scaling_config[0].desired_size]
+  }
+}

--- a/aws/eks_node_group/outputs.tf
+++ b/aws/eks_node_group/outputs.tf
@@ -1,0 +1,3 @@
+output "node_iam_role_arn" {
+  value = aws_iam_role.nodes.arn
+}

--- a/aws/eks_node_group/variables.tf
+++ b/aws/eks_node_group/variables.tf
@@ -1,0 +1,56 @@
+variable "cluster" {
+  description = "(Required) EKS Cluster to join."
+}
+
+variable "node_group_name_prefix" {
+  description = "(Required) Creates a unique name beginning with the specified prefix."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "(Required) Identifiers of EC2 Subnets to associate with the EKS Node Group."
+  type        = list(string)
+}
+
+variable "min_size" {
+  description = "(Optional) Minimum number of worker nodes."
+  default     = 3
+}
+
+variable "desired_size" {
+  description = "(Optional) Desired number of worker nodes."
+  default     = 3
+}
+
+variable "max_size" {
+  description = "(Optional) Maximum number of worker nodes."
+  default     = 6
+}
+
+variable "ec2_ssh_key" {
+  description = "(Optional) EC2 Key Pair name that provides access for SSH communication with the worker nodes in the EKS Node Group."
+  type        = string
+}
+
+variable "disk_size" {
+  default     = 20
+  description = "(Optional) Node disk size in GB"
+  type        = number
+}
+
+variable "capacity_type" {
+  description = "(Optional) Type of capacity associated with the EKS Node Group. Valid values: ON_DEMAND, SPOT. Defaults to ON_DEMAND."
+  default     = "ON_DEMAND"
+  type        = string
+}
+
+variable "instance_types" {
+  description = "(Optional) Set of instance types associated with the EKS Node Group. Defaults to [\"t3.medium\"]."
+  default     = ["t3.medium"]
+  type        = list(string)
+}
+
+variable "ami_type" {
+  description = "(Optional) Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to AL2_x86_64. Valid values: AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM."
+  default = "AL2_x86_64"
+}

--- a/aws/eks_node_group/variables.tf
+++ b/aws/eks_node_group/variables.tf
@@ -52,5 +52,5 @@ variable "instance_types" {
 
 variable "ami_type" {
   description = "(Optional) Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to AL2_x86_64. Valid values: AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM."
-  default = "AL2_x86_64"
+  default     = "AL2_x86_64"
 }


### PR DESCRIPTION
Per the discussion at our working group meeting today, this PR introduces a module to represent an EKS node group, that can be added to a cluster independently of the node group that `aws/eks` creates.

This approach allows us to perform zero-downtime updates to the EKS nodes in the node groups, when such an update requires rebuilding of the nodes (like for example, if we want to change the instance type we are using).