### PR TITLE
requiring the role for node gets created in eks module

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -122,7 +122,6 @@ resource "aws_eks_cluster" "main" {
 }
 
 data "aws_iam_policy_document" "nodes_assume_role_policy" {
-  count   = var.create_nodes ? 1 : 0
   version = "2012-10-17"
 
   statement {
@@ -138,27 +137,23 @@ data "aws_iam_policy_document" "nodes_assume_role_policy" {
 }
 
 resource "aws_iam_role" "nodes" {
-  count              = var.create_nodes ? 1 : 0
   name               = "${var.name}-nodes"
-  assume_role_policy = data.aws_iam_policy_document.nodes_assume_role_policy[0].json
+  assume_role_policy = data.aws_iam_policy_document.nodes_assume_role_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "nodes-AmazonEKSWorkerNodePolicy" {
-  count      = var.create_nodes ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-  role       = aws_iam_role.nodes[0].name
+  role       = aws_iam_role.nodes.name
 }
 
 resource "aws_iam_role_policy_attachment" "nodes-AmazonEKS_CNI_Policy" {
-  count      = var.create_nodes ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-  role       = aws_iam_role.nodes[0].name
+  role       = aws_iam_role.nodes.name
 }
 
 resource "aws_iam_role_policy_attachment" "nodes-AmazonEC2ContainerRegistryReadOnly" {
-  count      = var.create_nodes ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-  role       = aws_iam_role.nodes[0].name
+  role       = aws_iam_role.nodes.name
 }
 
 # Update the node_group name as part of an upgrade to a desctructive change.
@@ -183,7 +178,7 @@ resource "aws_eks_node_group" "default" {
   instance_types  = var.instance_types
   disk_size       = var.disk_size
   node_group_name = random_id.node-group-name[0].b64_url
-  node_role_arn   = aws_iam_role.nodes[0].arn
+  node_role_arn   = aws_iam_role.nodes.arn
   tags            = local.node_group_tags
 
   remote_access {

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -14,8 +14,8 @@ output "main_security_group_id" {
   value = aws_security_group.main.id
 }
 
-output "node_iam_role_arn" {
-  value = aws_iam_role.nodes.arn
+output "node_iam_role" {
+  value = aws_iam_role.node
 }
 
 output "oidc_provider" {

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -14,8 +14,8 @@ output "main_security_group_id" {
   value = aws_security_group.main.id
 }
 
-output "node_instance_role" {
-  value = var.create_nodes ? aws_iam_role.nodes[0].arn : null
+output "node_iam_role_arn" {
+  value = aws_iam_role.nodes.arn
 }
 
 output "oidc_provider" {

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -15,7 +15,7 @@ output "main_security_group_id" {
 }
 
 output "node_iam_role" {
-  value = aws_iam_role.node
+  value = aws_iam_role.nodes
 }
 
 output "oidc_provider" {

--- a/aws/eks_node_group/main.tf
+++ b/aws/eks_node_group/main.tf
@@ -16,7 +16,7 @@ resource "aws_eks_node_group" "nodes" {
   disk_size              = var.disk_size
   instance_types         = var.instance_types
   node_group_name_prefix = var.node_group_name_prefix
-  node_role_arn          = var.node_iam_role_arn
+  node_role_arn          = var.node_iam_role.arn
   tags                   = local.node_group_tags
 
   remote_access {
@@ -35,6 +35,7 @@ resource "aws_eks_node_group" "nodes" {
   # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
   depends_on = [
     var.cluster,
+    var.node_iam_role,
   ]
 
   # Do not detect Terraform drift for the desired size, so that the node group’s

--- a/aws/eks_node_group/main.tf
+++ b/aws/eks_node_group/main.tf
@@ -9,41 +9,6 @@ locals {
   node_group_tags = var.cluster.uses_cluster_autoscaler ? merge(var.cluster.tags, local.cluster_autoscaler_tags) : var.cluster.tags
 }
 
-data "aws_iam_policy_document" "nodes_assume_role_policy" {
-  version = "2012-10-17"
-
-  statement {
-    actions = [
-      "sts:AssumeRole",
-    ]
-
-    principals {
-      type        = "Service"
-      identifiers = ["ec2.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "nodes" {
-  name_prefix        = var.node_group_name_prefix
-  assume_role_policy = data.aws_iam_policy_document.nodes_assume_role_policy.json
-}
-
-resource "aws_iam_role_policy_attachment" "nodes-AmazonEKSWorkerNodePolicy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-  role       = aws_iam_role.nodes.name
-}
-
-resource "aws_iam_role_policy_attachment" "nodes-AmazonEKS_CNI_Policy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-  role       = aws_iam_role.nodes.name
-}
-
-resource "aws_iam_role_policy_attachment" "nodes-AmazonEC2ContainerRegistryReadOnly" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-  role       = aws_iam_role.nodes.name
-}
-
 resource "aws_eks_node_group" "nodes" {
   ami_type               = var.ami_type
   capacity_type          = var.capacity_type
@@ -51,7 +16,7 @@ resource "aws_eks_node_group" "nodes" {
   disk_size              = var.disk_size
   instance_types         = var.instance_types
   node_group_name_prefix = var.node_group_name_prefix
-  node_role_arn          = aws_iam_role.nodes.arn
+  node_role_arn          = var.node_iam_role_arn
   tags                   = local.node_group_tags
 
   remote_access {
@@ -70,9 +35,6 @@ resource "aws_eks_node_group" "nodes" {
   # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
   depends_on = [
     var.cluster,
-    aws_iam_role_policy_attachment.nodes-AmazonEKSWorkerNodePolicy,
-    aws_iam_role_policy_attachment.nodes-AmazonEKS_CNI_Policy,
-    aws_iam_role_policy_attachment.nodes-AmazonEC2ContainerRegistryReadOnly,
   ]
 
   # Do not detect Terraform drift for the desired size, so that the node group’s

--- a/aws/eks_node_group/outputs.tf
+++ b/aws/eks_node_group/outputs.tf
@@ -1,3 +1,0 @@
-output "node_iam_role_arn" {
-  value = aws_iam_role.nodes.arn
-}

--- a/aws/eks_node_group/variables.tf
+++ b/aws/eks_node_group/variables.tf
@@ -12,6 +12,10 @@ variable "subnet_ids" {
   type        = list(string)
 }
 
+variable "node_iam_role_arn" {
+  description = "(Required) The arn for the role to be associated with the nodes"
+}
+
 variable "min_size" {
   description = "(Optional) Minimum number of worker nodes."
   default     = 3

--- a/aws/eks_node_group/variables.tf
+++ b/aws/eks_node_group/variables.tf
@@ -12,8 +12,8 @@ variable "subnet_ids" {
   type        = list(string)
 }
 
-variable "node_iam_role_arn" {
-  description = "(Required) The arn for the role to be associated with the nodes"
+variable "node_iam_role" {
+  description = "(Required) The role to be associated with the nodes"
 }
 
 variable "min_size" {


### PR DESCRIPTION
This will solve the issue of a role getting recreated when we do a blue green deploy. 
A role for the node is created as part of the EKS module, and then is passed in as a variable to the EKS node group module. 