### PR TITLE
Adds support for RDS storage autoscaling.

### DIFF
--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -38,6 +38,7 @@ resource "aws_db_subnet_group" "mod" {
 
 resource "aws_db_instance" "mod" {
   allocated_storage           = var.storage
+  max_allocated_storage       = var.max_allocated_storage
   allow_major_version_upgrade = true
   apply_immediately           = true
   auto_minor_version_upgrade  = var.auto_minor_version_upgrade

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -95,6 +95,11 @@ variable "storage" {
   default     = 20
 }
 
+variable "max_allocated_storage" {
+  description = "Maximum Volume storage size for the RDS instance in gigabytes. Setting this will enable autoscaling of storage"
+  type        = number
+}
+
 variable "storage_encrypted" {
   description = "Encryption at rest"
   default     = false

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -98,6 +98,7 @@ variable "storage" {
 variable "max_allocated_storage" {
   description = "Maximum Volume storage size for the RDS instance in gigabytes. Setting this will enable autoscaling of storage"
   type        = number
+  default     = null
 }
 
 variable "storage_encrypted" {


### PR DESCRIPTION
Adds the parameter for 'max_allocated_storage' to enable AWS's new
autoscaling feature.
https://aws.amazon.com/about-aws/whats-new/2019/06/rds-storage-auto-scaling/
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#storage-autoscaling