### PR TITLE
ADD RDS storage autoscaling

### DIFF
--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -50,6 +50,7 @@ resource "aws_db_instance" "mod" {
   iops                        = var.iops
   instance_class              = var.node_type
   kms_key_id                  = var.kms_key_id
+  max_allocated_storage       = var.max_allocated_storage
   monitoring_interval         = var.monitoring_interval
   monitoring_role_arn         = var.monitoring_interval == 0 ? "" : aws_iam_role.rds_enhanced_monitoring[0].arn
   multi_az                    = var.multi_az

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -41,6 +41,12 @@ variable "kms_key_id" {
   default     = ""
 }
 
+variable "max_allocated_storage" {
+  description = "To enable storage autoscaling, you need to set this value to the upper limit of storage that RDS can automatically scale to. Must be greater then or equal to storage value." 
+  default = 0
+  type = number
+}
+
 variable "monitoring_interval" {
   default     = 60
   description = "(Optional) The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 60. Valid Values: 0, 1, 5, 10, 15, 30, 60."

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -42,9 +42,9 @@ variable "kms_key_id" {
 }
 
 variable "max_allocated_storage" {
-  description = "To enable storage autoscaling, you need to set this value to the upper limit of storage that RDS can automatically scale to. Must be greater then or equal to storage value." 
-  default = 0
-  type = number
+  description = "To enable storage autoscaling, you need to set this value to the upper limit of storage that RDS can automatically scale to. Must be greater then or equal to storage value."
+  default     = 0
+  type        = number
 }
 
 variable "monitoring_interval" {

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -42,7 +42,7 @@ variable "kms_key_id" {
 }
 
 variable "max_allocated_storage" {
-  description = "To enable storage autoscaling, you need to set this value to the upper limit of storage that RDS can automatically scale to. Must be greater then or equal to storage value."
+  description = "To enable storage autoscaling, you need to set this value to the upper limit of storage that RDS can automatically scale to. Must be greater then or equal to allocated_storage value."
   default     = 0
   type        = number
 }


### PR DESCRIPTION
Add the ability to use [RDS Storage Autoscaling](https://aws.amazon.com/about-aws/whats-new/2019/06/rds-storage-auto-scaling/) from the [RDS terraform module](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#storage-autoscaling).
