### PR TITLE
ADD the ability to manage EKS addons

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -123,7 +123,7 @@ resource "aws_eks_cluster" "main" {
 
 resource "aws_eks_addon" "main" {
   for_each         = toset(var.addons)
-  name             = aws_eks_cluster.main.name
+  cluster_name     = aws_eks_cluster.main.name
   addon_name       = each.key
   resolve_conflicts = var.addon_resolve_conflicts
 }

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -122,9 +122,9 @@ resource "aws_eks_cluster" "main" {
 }
 
 resource "aws_eks_addon" "main" {
-  for_each = toset(var.addons)
-  name = aws_eks_cluster.main.name
-  addon_name = each.key
+  for_each         = toset(var.addons)
+  name             = aws_eks_cluster.main.name
+  addon_name       = each.key
   resolve_conflict = var.addon_resolve_conflict
 }
 

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -121,6 +121,13 @@ resource "aws_eks_cluster" "main" {
   ]
 }
 
+resource "aws_eks_addon" "main" {
+  for_each = toset(var.addons)
+  name = aws_eks_cluster.main.name
+  addon_name = each.key
+  resolve_conflict = var.addon_resolve_conflict
+}
+
 data "aws_iam_policy_document" "nodes_assume_role_policy" {
   version = "2012-10-17"
 

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -122,9 +122,9 @@ resource "aws_eks_cluster" "main" {
 }
 
 resource "aws_eks_addon" "main" {
-  for_each         = toset(var.addons)
-  cluster_name     = aws_eks_cluster.main.name
-  addon_name       = each.key
+  for_each          = toset(var.addons)
+  cluster_name      = aws_eks_cluster.main.name
+  addon_name        = each.key
   resolve_conflicts = var.addon_resolve_conflicts
 }
 

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -125,7 +125,7 @@ resource "aws_eks_addon" "main" {
   for_each         = toset(var.addons)
   name             = aws_eks_cluster.main.name
   addon_name       = each.key
-  resolve_conflict = var.addon_resolve_conflict
+  resolve_conflicts = var.addon_resolve_conflicts
 }
 
 data "aws_iam_policy_document" "nodes_assume_role_policy" {

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -18,10 +18,6 @@ output "node_iam_role" {
   value = aws_iam_role.nodes
 }
 
-output "cluster_security_group_id" {
-  value = aws_eks_cluster.master.vpc_config[0].cluster_security_group_id
-}
-
 output "oidc_provider" {
   value = aws_iam_openid_connect_provider.default.arn
 }

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -91,7 +91,7 @@ variable "create_nodes" {
 variable "addons" {
   description = "(Optional) List of EKS addons to manage"
   default     = []
-  type        = list
+  type        = list(string)
 }
 
 variable "addon_resolve_conflict" {

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -90,12 +90,12 @@ variable "create_nodes" {
 
 variable "addons" {
   description = "(Optional) List of EKS addons to manage"
-  default = []
-  type = list
+  default     = []
+  type        = list
 }
 
 variable "addon_resolve_conflict" {
   description = "EKS addon conflict resolution NONE|OVERWRITE"
-  default = "OVERWRITE"
-  type = string
+  default     = "OVERWRITE"
+  type        = string
 }

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -94,7 +94,7 @@ variable "addons" {
   type        = list(string)
 }
 
-variable "addon_resolve_conflict" {
+variable "addon_resolve_conflicts" {
   description = "EKS addon conflict resolution NONE|OVERWRITE"
   default     = "OVERWRITE"
   type        = string

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -87,3 +87,15 @@ variable "create_nodes" {
   description = "(Optional) Create a node group for the EKS cluster. Defaults to true."
   default     = true
 }
+
+variable "addons" {
+  description = "(Optional) List of EKS addons to manage"
+  default = []
+  type = list
+}
+
+variable "addon_resolve_conflict" {
+  description = "EKS addon conflict resolution NONE|OVERWRITE"
+  default = "OVERWRITE"
+  type = string
+}


### PR DESCRIPTION
EKS has added the ability to manage [add-on services](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) (Amazon VPC CNI, CoreDNS, etc.) automatically vs having to manually manage these services using other tooling like kustomize. This is really helpful when handling kubernete cluster upgrades which often includes patching image versions and modifying clusterrole/role permissions.
