### PR TITLE
ADD node_role_arn output to EKS module

### DIFF
--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -53,3 +53,7 @@ output "tags" {
 output "name" {
   value = aws_eks_cluster.main.name
 }
+
+output "node_role_arn" {
+  value = aws_iam_role.nodes.arn
+}


### PR DESCRIPTION
For situtations where the node group is getting defined outside this module or when multiple node groups are necessary for a cluster, we need access to the role arn generated for the node group.
