### PR TITLE
Use 1 instead of true for ELB tags

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -3,7 +3,7 @@ locals {
   tags              = merge({ Name = var.name, eks_cluster_name = var.name }, var.tags)
 
   subnet_tags = merge(local.tags, {
-    (local.elb_discovery_tag)           = true,
+    (local.elb_discovery_tag)           = 1,
     "kubernetes.io/cluster/${var.name}" = "shared"
   })
 


### PR DESCRIPTION
Per [the guide for AWS’s Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/deploy/subnet_discovery/#public-subnets), the value for ELB-related tags should be 1, rather than “true”.

This PR changes it, so that the subnets can be auto-discovered.