### PR TITLE
Make aws/rds compatible with version 4 of AWS provider

### DIFF
--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -68,12 +68,6 @@ resource "aws_db_instance" "mod" {
     var.vpc_security_group_ids,
     [aws_security_group.sg_on_rds_instance.id],
   )
-
-  lifecycle {
-    ignore_changes = [
-      latest_restorable_time
-    ]
-  }
 }
 
 resource "aws_security_group" "sg_on_rds_instance" {

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -42,7 +42,7 @@ resource "aws_db_instance" "mod" {
   apply_immediately            = true
   auto_minor_version_upgrade   = var.auto_minor_version_upgrade
   backup_retention_period      = var.backup_retention_period
-  db_subnet_group_name         = var.source_db == "" ? local.subnet_group_name : ""
+  db_subnet_group_name         = local.subnet_group_name
   engine                       = var.engine
   engine_version               = var.engine_version
   final_snapshot_identifier    = "${var.name}-${var.env}-${var.engine}-final-snapshot"
@@ -58,7 +58,6 @@ resource "aws_db_instance" "mod" {
   password                     = "nopassword"
   performance_insights_enabled = var.performance_insights_enabled
   publicly_accessible          = var.publicly_accessible
-  replicate_source_db          = var.source_db
   skip_final_snapshot          = var.skip_final_snapshot
   storage_encrypted            = var.storage_encrypted
   storage_type                 = var.storage_type

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -96,11 +96,6 @@ variable "skip_final_snapshot" {
   default     = false
 }
 
-variable "source_db" {
-  description = "recplication source db"
-  default     = ""
-}
-
 variable "storage" {
   description = "Volume storage size for the RDS instance in gigabytes."
   default     = 20


### PR DESCRIPTION
When trying to upgrade Dickson’s Terraform installation to use version 4 of the AWS provider, we ran into a bunch of these errors:

```
╷
│ Error: Conflicting configuration arguments
│ 
│   with module.calclub-production-rds.aws_db_instance.mod,
│   on .terraform/modules/calclub-production-rds/aws/rds/main.tf line 66, in resource "aws_db_instance" "mod":
│   66:   username                     = var.username != "" ? var.username : "${var.name}${var.username_suffix}"
│ 
│ "username": conflicts with replicate_source_db
╵
```

Since we now have the module `aws/database_replica` for creating RDS replicas, this PR removes `var.source_db` from the module `aws/rds`, which fixes the problems and allows Terraform to proceed with a plan.