### PR TITLE
ADD server_side_encryption_configuration rule to static site module

### DIFF
--- a/aws/static_site/main.tf
+++ b/aws/static_site/main.tf
@@ -40,6 +40,15 @@ resource "aws_s3_bucket" "mod" {
     index_document = var.index_document
     error_document = var.index_document
   }
+
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 locals {


### PR DESCRIPTION
Brings the static site module into alignment with other modules that use the s3 resource.